### PR TITLE
update notices, add triage doc

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -56,6 +56,40 @@ This software includes third-party packages and libraries. The complete list of 
 - **Source**: https://rasterio.readthedocs.io/
 - **Usage**: Geospatial raster data I/O
 
+## Build / Development Tooling (Not Redistributed)
+
+The following weak-copyleft (LGPL / MPL-2.0) packages appear in the maintainer-side build/development conda environments (`env.yml`, `env_build.yml`) as transitive dependencies of build tools (`hatch`, `azure-cli`, `fabric`, `black`). They are **not redistributed as part of the published HASTE package** — consumers of HASTE do not receive these packages from this project. They are listed here for transparency only.
+
+| Package | License | Pulled in by |
+|---|---|---|
+| `paramiko` | LGPL-2.1 | `hatch` → `azure-cli` |
+| `chardet` | LGPL-2.1-or-later | `azure-cli` |
+| `PyGithub` | LGPL | `hatch` / `azure-cli` |
+| `scp` | LGPL-2.1-or-later | `azure-cli` → `fabric` |
+| `pathspec` | MPL-2.0 | `black` / `hatch` |
+
+These packages are imported and used unmodified at build/development time. No source modification, vendoring, or static linking is performed.
+
+## Proprietary Components (Non-OSS, Redistribution Permitted)
+
+The following Microsoft components are **not open-source licensed** but are redistributed in HASTE under the terms of their respective licenses. Consumers integrating HASTE should review these license terms separately from the project's MIT license.
+
+### Azure Maps Web SDK
+- **Package**: `azure-maps-control` (transitive, via `azure-maps-drawing-tools`)
+- **License**: Microsoft Azure Maps Web SDK End User License Agreement (proprietary)
+- **License Terms**: https://azuremapscdn.azureedge.net/sdk-licenses/atlas.min.LICENSE.txt
+- **Source**: https://learn.microsoft.com/en-us/azure/azure-maps/how-to-use-map-control
+- **Usage**: Interactive map rendering and geospatial visualization in the UI
+
+### Azure Maps Drawing Tools
+- **Package**: `azure-maps-drawing-tools` (direct dependency)
+- **License**: Microsoft Software License Terms (proprietary)
+- **License Terms**: https://azuremapscdn.azureedge.net/sdk-licenses/drawing/LICENSE.txt
+- **Source**: https://learn.microsoft.com/en-us/azure/azure-maps/set-drawing-options
+- **Usage**: Map drawing and shape-editing controls in the UI
+
+Use of these components requires an Azure Maps account and is subject to Azure service terms.
+
 ## Additional Notices
 
 This software may include additional third-party software components. For a complete and up-to-date list of all dependencies and their licenses, please refer to the package manifest files listed above.

--- a/docs/known-vulnerabilities.md
+++ b/docs/known-vulnerabilities.md
@@ -4,6 +4,8 @@ This document tracks Dependabot alerts that are deferred because they cannot be 
 
 Update this file when upstream packages ship fixes or when the deployment model changes.
 
+For the triage workflow, ownership, and SLAs that govern when entries land here, see [triage-process.md](triage-process.md).
+
 ---
 
 ## ~~Root Cause A — azurite → @azure/ms-rest-js (deprecated)~~ — RESOLVED

--- a/docs/triage-process.md
+++ b/docs/triage-process.md
@@ -1,0 +1,94 @@
+# Vulnerability Triage Process
+
+How the HASTE maintainers handle security signals — Dependabot alerts, CodeQL findings, secret-scan results, and externally-reported vulnerabilities.
+
+This document covers the **internal triage workflow**. For instructions on how to **report a vulnerability** to Microsoft, see [SECURITY.md](../SECURITY.md) and [aka.ms/SECURITY.md](https://aka.ms/SECURITY.md).
+
+Companion document: [known-vulnerabilities.md](known-vulnerabilities.md) — the running log of dismissed/risk-accepted alerts and their rationale.
+
+---
+
+## Scope
+
+In-repo security signals:
+
+- **Dependabot** alerts (root and `ui/` package graphs).
+- **CodeQL** findings (`.github/workflows/codeql.yml`, runs on every PR and weekly on `main`).
+- **GitHub secret scanning** alerts (push protection + repo scan).
+- **External vulnerability reports** routed via [SECURITY.md](../SECURITY.md) and MSRC.
+
+## Ownership
+
+- **Primary owners:** Repo maintainers listed in [`.github/CODEOWNERS`](../.github/CODEOWNERS) (`@microsoft/haste-maintainers`).
+- **External report coordination:** Microsoft Security Response Center (MSRC) via [aka.ms/SECURITY.md](https://aka.ms/SECURITY.md). Maintainers cooperate; MSRC drives disclosure timing.
+- **Final risk-acceptance sign-off:** Project lead. For anything labelled `Critical` or `High` the sign-off must be in writing (PR description, comment on the dismissed alert, or commit message).
+
+## Triage cadence and SLAs
+
+| Signal | Initial triage | Remediate or waive by |
+|---|---|---|
+| Dependabot — Critical | 1 business day | 7 days |
+| Dependabot — High | 5 business days | 14 days |
+| Dependabot — Medium | 10 business days | 30 days |
+| Dependabot — Low | Best-effort during normal review | Document if deferred > 90 days |
+| CodeQL — High or Critical | At PR review (blocks merge) | Before merge |
+| CodeQL — Medium / Low | At PR review | Before next release |
+| Secret scanning — confirmed leak | Within 24 hours | Rotate immediately; revoke first, then push fix |
+| External report (MSRC) | Acknowledge within 5 business days | Per MSRC policy |
+
+"Initial triage" = an explicit decision is recorded (fix queued / dismiss with reason / risk-accept).
+
+A monthly sweep reviews all dismissed alerts older than 90 days to confirm waivers are still valid (e.g., upstream may have shipped a fix, threat model may have changed).
+
+## Workflow per signal
+
+### Dependabot alert
+
+1. **Read** the alert: package, advisory ID (CVE/GHSA), severity, affected paths.
+2. **Reachability check** — does any application code path actually reach the vulnerable function? For UI deps, are they used in production code or only in build/dev tooling?
+3. **Decide:**
+   - **Fix:** accept the Dependabot PR, or open a manual upgrade PR if the bot's PR is blocked (peer dep conflicts, breaking changes). Regenerate lockfiles.
+   - **Dismiss as `tolerable_risk`:** only if (a) not reachable from app code, or (b) blocked on upstream and risk is bounded. Record the reason in [known-vulnerabilities.md](known-vulnerabilities.md) **and** in the GitHub dismissal comment.
+   - **Dismiss as `not_used`:** dependency is dev-only and unreachable in production.
+4. **Verify** in the next Dependabot rescan (`gh api repos/microsoft/haste/dependabot/alerts?state=open`).
+
+### CodeQL finding
+
+1. Findings appear as PR review comments and on the Security tab.
+2. **High/Critical** findings block PR merge — fix or document a justified dismissal in the PR conversation.
+3. **Medium/Low** findings — fix in the same PR if cheap; otherwise file a follow-up issue with a target release.
+4. Periodic dismissals require justification recorded on the alert.
+
+### Secret scanning alert
+
+1. Push protection should catch most leaks before commit; if a leak is committed:
+   - **Rotate first** — revoke the leaked credential immediately on the issuing system (Azure portal, key vault, etc.).
+   - **Then** force-remove the secret from history if it's still in the working tree, or document its presence if the rotation makes the leak benign (well-known dev keys, expired tokens).
+2. Update `.gitleaks.toml` / `detect-secrets` baseline only after rotation; never to suppress an unresolved leak.
+
+### External report (MSRC)
+
+1. Reports come via [aka.ms/SECURITY.md](https://aka.ms/SECURITY.md) → MSRC.
+2. MSRC notifies maintainers via private channel and assigns a case number.
+3. Maintainers cooperate with MSRC on reproducer, fix, and disclosure timing. Public commit / advisory waits until MSRC says go.
+
+## Escalation
+
+- **Critical** severity or evidence of active exploitation in the wild → notify MSRC and project lead immediately; assume incident-response cadence rather than the table above.
+- Cannot remediate within the SLA window → open a tracking issue, document the blocker (upstream not patched, breaking-change cost, etc.), and obtain explicit risk-acceptance sign-off recorded on the issue.
+- Disagreement on disposition → escalate to the security review team contact (currently Pedro Enriquez's team, per the 2026-05-01 review).
+
+## Records
+
+- **Open and historical alerts:** GitHub Security tab + `gh api repos/microsoft/haste/dependabot/alerts`.
+- **Documented dismissals and waivers:** [known-vulnerabilities.md](known-vulnerabilities.md).
+- **External reports:** MSRC case files (private).
+
+## Reviewing this process
+
+Revisit this document whenever:
+
+- The OSS deployment / hosting model changes (e.g., HASTE adds a hosted service).
+- New scanning tools are added (e.g., container image scanning, Snyk).
+- The maintainer set changes materially.
+- A real incident exposes a gap.


### PR DESCRIPTION
Adds third party notice information based on license check, as well as triage doc for Dependabot alerts
