### PR TITLE
fix(ui): make labeling tool work without an Azure Maps subscription

### DIFF
--- a/ui/src/Components/LabelingTool/LabelingTool.jsx
+++ b/ui/src/Components/LabelingTool/LabelingTool.jsx
@@ -10,7 +10,7 @@ import {
   loadStudyArea,
   centrateMap,
 } from "./LabelingToolHelper.js";
-import { getAzureMapsAuthOptions } from "../../util/azureMapsAuth";
+import { getAzureMapsAuthOptions, isAzureMapsPlaceholder } from "../../util/azureMapsAuth";
 import { useParams } from "react-router-dom";
 import LabelingToolLeftPanel from "./LabelingToolLeftPanel.jsx";
 import LabelingToolRightPanel from "./LabelingToolRightPanel.jsx";
@@ -187,7 +187,7 @@ const LabelingTool = ({ setModalComponent }) => {
       zoom: 3,
       maxPitch: 0,
       pitch: 0,
-      style: "grayscale_light",
+      style: isAzureMapsPlaceholder ? "blank" : "grayscale_light",
       language: "en-US",
       authOptions: getAzureMapsAuthOptions(),
     });

--- a/ui/src/util/azureMapsAuth.js
+++ b/ui/src/util/azureMapsAuth.js
@@ -5,11 +5,37 @@ import { apiGet } from "./api";
 
 const AZURE_MAPS_CLIENT_ID = import.meta.env.VITE_AZURE_MAPS_CLIENT_ID;
 
+const isPlaceholderClientId =
+  !AZURE_MAPS_CLIENT_ID ||
+  AZURE_MAPS_CLIENT_ID === "placeholder" ||
+  AZURE_MAPS_CLIENT_ID.startsWith("placeholder");
+
 /**
  * Fetches an Azure AD token for Azure Maps from the backend API.
  * Used by the Azure Maps SDK anonymous authentication flow.
+ *
+ * In local development VITE_AZURE_MAPS_CLIENT_ID is left at its placeholder
+ * default and the backend GetAzureMapsToken endpoint cannot mint a token
+ * (no managed identity, no az login cache mounted). Resolving with a fake
+ * non-empty JWT (instead of "") short-circuits the SDK so the labeling tool
+ * still initializes — empty strings are rejected as auth failure and the
+ * map control stops firing its "ready" event, which prevents zoom controls,
+ * custom TileLayers, and study-area outlines from being added.
+ *
+ * The token isn't actually sent to atlas.microsoft.com because callers also
+ * pick a basemap style that doesn't require an Azure Maps subscription
+ * (see isAzureMapsPlaceholder usage in LabelingTool.jsx).
  */
 async function getAzureMapsToken(resolve, reject) {
+  if (isPlaceholderClientId) {
+    // RFC 7519-shaped placeholder. Header={"alg":"none","typ":"JWT"},
+    // payload={"sub":"haste-local-dev","exp":4102444800} (year 2100).
+    resolve(
+      "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0." +
+        "eyJzdWIiOiJoYXN0ZS1sb2NhbC1kZXYiLCJleHAiOjQxMDI0NDQ4MDB9."
+    );
+    return;
+  }
   try {
     const response = await apiGet("GetAzureMapsToken");
     resolve(response.access_token);
@@ -29,3 +55,11 @@ export function getAzureMapsAuthOptions() {
     getToken: getAzureMapsToken,
   };
 }
+
+/**
+ * True when the deployment has not been wired up to a real Azure Maps account
+ * (i.e. local docker-compose dev). Callers should use the "blank" map style
+ * in this case so the map control can initialize without fetching styles
+ * from atlas.microsoft.com (which requires a real token).
+ */
+export const isAzureMapsPlaceholder = isPlaceholderClientId;


### PR DESCRIPTION
Lets the labeling tool initialize when no Azure Maps subscription is configured (local docker-compose dev with `VITE_AZURE_MAPS_CLIENT_ID=placeholder`).

- `getAzureMapsToken` resolves with a well-formed unsigned JWT instead of `""`, so the SDK fires its `ready` event (empty tokens are treated as auth failure, which suppresses zoom controls, imagery TileLayers, and the study-area outline).
- `atlas.Map` uses `style: "blank"` in placeholder mode so the SDK doesn't try to fetch `grayscale_light` style/sprites from `atlas.microsoft.com`.

Production behavior is unchanged when a real client ID is configured.

This allows me to see the local imagery served through TiTiler without the Azure maps key stuff:

<img width="1544" height="1338" alt="image" src="https://github.com/user-attachments/assets/a521d999-409e-4374-9b7a-98b53d1c5fb2" />


