### PR TITLE
docs: fix stale haste/haste_geo references in README and docker/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,9 +222,9 @@ hatch build -t wheel
 ```
 
 The `hatch build` command automatically:
-- Increments the version in `hastelib/src/haste_geo/__about__.py`
-- Builds a wheel and copies it to the function app folders
-- Updates the package version in all `requirements.txt` and `env.yml` files
+- Increments the version in `hastelib/src/hastegeo/__about__.py`
+- Builds a wheel, uploads it to the `haste-binaries` blob container, and removes the local copy from `hastelib/dist/`
+- Rewrites the pinned wheel URL on the `hastegeo @ <url>` line of `api/hastefuncapi/requirements.txt`, `api/hastefuncqueues/requirements.txt`, and `docker/imageryprep/requirements.txt`
 
 Then deploy the function apps:
 
@@ -267,10 +267,10 @@ func azure functionapp publish <YOUR_TITILER_FUNCTION_NAME> --python
 
 ### Testing batch jobs locally
 
-Mount the `haste` package in hot-reload mode by adding this volume to your `docker run` command:
+Mount the `hastegeo` package in hot-reload mode by adding this volume to your `docker run` command:
 
 ```bash
--v "`pwd`/hastelib/src/haste_geo":/usr/local/lib/python3.11/site-packages/haste
+-v "`pwd`/hastelib/src/hastegeo":/usr/local/lib/python3.11/site-packages/hastegeo
 ```
 
 #### Imagery prep
@@ -298,7 +298,7 @@ post_event_imagery_urls:
 ```bash
 docker run -it \
   -v "`pwd`/localtmp/prepare_imagery":/wd \
-  -v "`pwd`/hastelib/src/haste_geo":/usr/local/lib/python3.11/site-packages/haste \
+  -v "`pwd`/hastelib/src/hastegeo":/usr/local/lib/python3.11/site-packages/hastegeo \
   -e WORKDIR=/wd \
   --entrypoint bash \
   ${CONTAINER_REGISTRY}.azurecr.io/hasteimageryprep:${tag}
@@ -310,7 +310,7 @@ docker run -it \
 prepare-imagery --config /wd/imageryprep_config.json
 ```
 
-Outputs are written to `localtmp/prepare_imagery/outputs/`. Changes to `hastelib/src/haste_geo/workflows/prepare_imagery.py` are reflected immediately via the volume mount.
+Outputs are written to `localtmp/prepare_imagery/outputs/`. Changes to `hastelib/src/hastegeo/workflows/prepare_imagery.py` are reflected immediately via the volume mount.
 
 #### Training
 
@@ -323,7 +323,7 @@ Outputs are written to `localtmp/prepare_imagery/outputs/`. Changes to `hastelib
 ```bash
 docker run --gpus all -it --shm-size=32g \
   -v "`pwd`/localtmp/training":/wd \
-  -v "`pwd`/hastelib/src/haste_geo":/usr/local/lib/python3.11/site-packages/haste \
+  -v "`pwd`/hastelib/src/hastegeo":/usr/local/lib/python3.11/site-packages/hastegeo \
   -v "`pwd`/docker/training:/app" \
   -e WORKDIR=/wd \
   --entrypoint bash \

--- a/docker/README.md
+++ b/docker/README.md
@@ -420,7 +420,7 @@ hastefuncapi + hastefuncqueues + titiler
   so the dashboard shows existing projects after a container restart.
 - **Bind mount:** `../data:/app/data` for local data access.
 - **Docker socket mount:** `/var/run/docker.sock` (read-only, for future extensibility).
-- Copies `hastelib/src/haste_geo` directly into the image (avoids wheel installation in Docker).
+- Copies `hastelib/src/hastegeo` directly into the image (avoids wheel installation in Docker).
 
 #### hastefuncqueues (Queue Worker)
 
@@ -436,7 +436,7 @@ hastefuncapi + hastefuncqueues + titiler
   - `../data:/app/data`
   - `azurite-data:/shared/azurite` — **shared Named Volume** with Azurite for direct file-system reads
   - `/var/run/docker.sock:/var/run/docker.sock` — **required** to spawn training/imageryprep containers
-- Copies `hastelib/src/haste_geo` directly into the image.
+- Copies `hastelib/src/hastegeo` directly into the image.
 
 ### UI Service
 
@@ -629,7 +629,7 @@ http://<HOST_IP>:4280
 
 ## Rebuilding the Haste Wheel
 
-The `hastelib/` directory contains the shared Python library (`haste` package) used by
+The `hastelib/` directory contains the shared Python library (`hastegeo` package) used by
 the API services, imageryprep, and training containers. In the Docker deployment, the
 source is **copied directly** into images (no wheel install needed).
 
@@ -647,14 +647,13 @@ python -m build --wheel
 ```
 
 The custom `haste_build.py` script:
-1. Increments the version in `src/haste/__about__.py`
-2. Builds a `.whl` file
-3. Uploads it to `researchlabwuopendata.blob.core.windows.net/haste-binaries/`
-4. Copies the `.whl` to `api/hastefuncapi/` and `api/hastefuncqueues/`
-5. Updates the `requirements.txt` files with the new wheel URL
+1. Increments the version in `src/hastegeo/__about__.py`
+2. Builds a `.whl` file under `hastelib/dist/`
+3. Uploads it to `researchlabwuopendata.blob.core.windows.net/haste-binaries/` (requires `az login`) and removes the local copy from `hastelib/dist/`
+4. Rewrites the `hastegeo @ <url>` line in `api/hastefuncapi/requirements.txt`, `api/hastefuncqueues/requirements.txt`, and `docker/imageryprep/requirements.txt` so they pin the new wheel URL
 
 > **For local Docker**, you do NOT need to rebuild the wheel — the Dockerfiles
-> copy the source directly with `COPY hastelib/src/haste_geo /home/site/wwwroot/haste`.
+> copy the source directly with `COPY hastelib/src/hastegeo /home/site/wwwroot/hastegeo`.
 
 ---
 


### PR DESCRIPTION
## What

Cleans up stale references that survived the `hasteutils` → `hastelib` / `haste` → `hastegeo` package rename, in the two top-level READMEs.

## Why

Hit while bumping `hastegeo` to 1.0.3 on PR #24 and trying to follow the version-bump docs. Both READMEs describe `haste_build.py`'s behavior with paths and a step list that no longer match the actual hook:

- They reference `src/haste/__about__.py` / `src/haste_geo/__about__.py` — the file lives at `src/hastegeo/__about__.py`.
- The `docker/README.md` step list claims the wheel is *'copied to api/hastefuncapi/ and api/hastefuncqueues/'*. The hook actually uploads it to the `haste-binaries` Azure blob container, deletes it from `hastelib/dist/`, and rewrites the `hastegeo @ <url>` pin in three `requirements.txt` files (the third being `docker/imageryprep/requirements.txt`, which neither README mentioned).
- The root README also mentions `env.yml` as one of the rewritten files; `haste_build.py` does have an `env_yml_path = '../env.yml'` block, but no such file exists in the repo, so the line is misleading.
- A couple of `docker run` snippets in the 'Testing batch jobs locally' section mount `hastelib/src/haste_geo` at `/usr/local/lib/python3.11/site-packages/haste`; both halves of that mapping are out of date.

## Changes

- **README.md** — corrected the `hatch build` step list under 'Deploying Azure Functions', and the two volume-mount snippets + surrounding prose under 'Testing batch jobs locally'.
- **docker/README.md** — corrected the parallel `haste_build.py` step list under 'Rebuilding the Haste Wheel', plus two service-overview bullets that say *'Copies hastelib/src/haste_geo'* and the inline `COPY` example.

No behavior change — docs only.

## Verification

`grep -rn 'haste_geo\|src/haste/__about__\|src/haste ' README.md docker/README.md` now returns no matches.