### PR TITLE
handle dependabot build checks differently to avoid replicating secrets

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -84,8 +84,37 @@ jobs:
             echo "run=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # Dependabot PRs don't receive repo Actions secrets, so Azure Login fails
+      # and the regular push path can't run. Build locally on the runner and
+      # smoke-test imports inside the image so dependency bumps that break the
+      # application's API surface are caught even though we can't push.
+      - name: Build image locally (Dependabot PRs)
+        if: steps.resolve.outputs.run == 'true' && github.actor == 'dependabot[bot]'
+        shell: bash
+        env:
+          IMAGE_DIR: ${{ matrix.image_dir }}
+        run: |
+          docker build -f "docker/${IMAGE_DIR}/Dockerfile" -t "haste${IMAGE_DIR}:ci-smoke" .
+
+      - name: Smoke test image (Dependabot PRs)
+        if: steps.resolve.outputs.run == 'true' && github.actor == 'dependabot[bot]'
+        shell: bash
+        env:
+          IMAGE_DIR: ${{ matrix.image_dir }}
+        run: |
+          case "$IMAGE_DIR" in
+            imageryprep)
+              docker run --rm --entrypoint python "haste${IMAGE_DIR}:ci-smoke" -c \
+                "import hastegeo.workflows.prepare_imagery; import hastegeo.workflows.zip_artifacts; print('imageryprep imports OK')"
+              ;;
+            training)
+              docker run --rm --entrypoint python "haste${IMAGE_DIR}:ci-smoke" -c \
+                "import bda; import bda.preprocess; import bda.trainers; import hastegeo; print('training imports OK')"
+              ;;
+          esac
+
       - name: Azure Login
-        if: steps.resolve.outputs.run == 'true'
+        if: steps.resolve.outputs.run == 'true' && github.actor != 'dependabot[bot]'
         uses: azure/login@v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -93,7 +122,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Build and Push Docker Image
-        if: steps.resolve.outputs.run == 'true'
+        if: steps.resolve.outputs.run == 'true' && github.actor != 'dependabot[bot]'
         shell: bash
         env:
           ACR_NAME: ${{ secrets.ACR_NAME }}


### PR DESCRIPTION
## Description

Dependabot PRs were failing the `Build and Push Docker Images` workflow with `Login failed... 'client-id' and 'tenant-id' are supplied`. Root cause: GitHub does not pass repository Actions secrets to workflows triggered from Dependabot
PRs (they live in a separate Dependabot secret store), so `secrets.AZURE_*` silently expanded to empty strings and `azure/login` rejected the empty values.
Rather than mirror the OIDC secrets into the Dependabot store (which would extend ACR push trust to the bot account), this change routes Dependabot PRs through a no-secrets validation path:

- Build the image locally on the runner with `docker build` (no Azure auth needed).
- Smoke-test the built image by importing the workflow modules it is supposed to expose (`hastegeo.workflows.*` for imageryprep; `bda` + `hastegeo` for training). This catches the failure modes a dep bump typically introduces
  — removed attributes, renamed modules, breaking signature changes that surface at import time — without needing the application's full runtime environment.
- Skip Azure Login and the `az acr build` push entirely for Dependabot PRs; those PRs are about validating the dep bump, not promoting an image.

Regular contributor PRs and `workflow_dispatch` runs are unchanged: they still authenticate via OIDC and push to ACR exactly as before.


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [x] Infrastructure / CI change

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My changes follow the project's coding standards (PEP 8 for Python, ESLint rules for JS/TS)
- [ ] ~~I have added or updated tests that cover my changes~~ N/A
- [ ] ~~All existing tests pass locally (`pytest` / `npm test`)~~ N/A
- [x] I have updated the relevant documentation (README, docs/, inline comments)
- [ ] ~~I have added an entry to [CHANGELOG.md](../CHANGELOG.md) if this is a user-facing change~~ (not user-facing — CI-only change)

## Testing

Workflow YAML change only — no application code touched, so no unit tests apply. Validation of the new path requires a Dependabot-triggered run after merge, since the smoke-test steps are gated on `github.actor == 'dependabot[bot]'`.

Plan to verify after merge:

1. Confirm the existing failing Dependabot PR (`dependabot/pip/docker/imageryprep/geopandas-1.1.2`) — comment
   `@dependabot recreate` so it rebuilds off the updated `main`.
2. Watch the resulting `Build and Push Docker Images` run: the new `Build image locally (Dependabot PRs)` and `Smoke test image (Dependabot PRs)`  steps should execute; `Azure Login` and `Build and Push Docker Image` should be skipped.
3. Confirm that on a normal contributor PR (e.g. the next push to a `mgmachado/*` branch), the new Dependabot-only steps are skipped and the existing OIDC + `az acr build` path runs unchanged.

## Additional context

Scoping note: the local-build-and-smoke path is intentionally scoped to Dependabot PRs only. Making it universal would mean building each image twice on every PR (once locally for the smoke test, once on ACR for the push), which is non-trivial for the training image (~10-20 min, multi-stage conda env). If we later want universal smoke testing, the cleanest path is to switch the push to local-build + `docker push` and retire `az acr build` from this workflow — out of scope for this fix.

What this change does **not** catch: behavioral regressions that only show up when the image runs against real data (e.g. a silently-changed CRS default in a geopandas bump). Those require an integration test against a deployed environment, which is currently covered downstream by `deploy-apps.yml`.