### PR TITLE
fix(ui): make 'Don't show again' on guided tours actually persist

### DIFF
--- a/ui/src/Components/GuidedTour.jsx
+++ b/ui/src/Components/GuidedTour.jsx
@@ -25,9 +25,14 @@ const GuidedTour = () => {
 
   useEffect(() => {
     if (appParams.currentTour) {
-      if(!appParams.userSettings.disableGuidedTour || !validateIsGuidedTourDisabled(appParams.currentTour.cookieName)) {
-        setIsVisible(true);
-      }
+      const shouldShow =
+        !appParams.userSettings.disableGuidedTour &&
+        !validateIsGuidedTourDisabled(appParams.currentTour.cookieName);
+      // Explicitly reset rather than only flipping to true; otherwise a
+      // previously-shown tour leaves isVisible=true and a freshly-started
+      // tour that should be hidden ("Don't show again" already clicked)
+      // would briefly render before being dismissed.
+      setIsVisible(shouldShow);
 
       const filteredSteps = appParams.currentTour.steps.filter((step) => {
         if (step.type !== "teachingBubble") {

--- a/ui/src/Components/GuidedTourHelper.js
+++ b/ui/src/Components/GuidedTourHelper.js
@@ -1,28 +1,61 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-  export function validateIsGuidedTourDisabled(cookieName) {
-    const sessionStorageValue = sessionStorage.getItem(cookieName + "Disabled");
-    if (sessionStorageValue === "false") {
-        return false;
-    }else if (sessionStorageValue === null  || sessionStorageValue === "true") {
-        return true;
-    }
 
-    return false;
+// Per-tour "Don't show again" state is persisted to localStorage so it
+// survives reloads, new tabs, and browser restarts (sessionStorage was a
+// per-tab kludge that lost the dismissal as soon as the user closed the
+// window). The values written here form a deliberately small alphabet:
+//
+//   missing/null     — user has never decided; treat as "not disabled"
+//                      so first-time visitors still see the tour
+//   "true"           — user clicked "Don't show again"; tour stays hidden
+//   "false"          — user clicked Help (or otherwise explicitly
+//                      re-enabled); tour is shown again
+const STORAGE_KEY_SUFFIX = "Disabled";
+
+function _storageKey(cookieName) {
+  return cookieName + STORAGE_KEY_SUFFIX;
+}
+
+function _resolveCookieName(currentTour, guidedTourProperties) {
+  return (
+    guidedTourProperties.find((tour) => tour.name === currentTour)
+      ?.cookieName || "tourGuide"
+  );
+}
+
+export function validateIsGuidedTourDisabled(cookieName) {
+  // Treat only the explicit "true" sentinel as disabled. A missing or
+  // null entry means the user has not dismissed this tour yet, so we
+  // want to show it.
+  return localStorage.getItem(_storageKey(cookieName)) === "true";
+}
+
+export function initGuidedTourState(
+  currentTour,
+  guidedTourProperties,
+  value = false,
+) {
+  // Initialize the storage entry only if it doesn't already exist. This
+  // used to unconditionally overwrite whatever the user had previously
+  // chosen, which is why "Don't show again" appeared not to persist.
+  const key = _storageKey(_resolveCookieName(currentTour, guidedTourProperties));
+  if (localStorage.getItem(key) === null) {
+    localStorage.setItem(key, value);
   }
+}
 
-  export function initGuidedTourState(currentTour, guidedTourProperties, value = true ) {
-    const cookieName = guidedTourProperties.find((tour) => tour.name === currentTour)?.cookieName || "tourGuide";
-    sessionStorage.setItem(cookieName + "Disabled", value);
+export function setGuidedTourState(
+  isGuidedTourDisabled,
+  initCurrentTour,
+  currentTour,
+  guidedTourProperties,
+) {
+  const cookieName = _resolveCookieName(currentTour, guidedTourProperties);
+  localStorage.setItem(_storageKey(cookieName), isGuidedTourDisabled);
+  if (isGuidedTourDisabled) {
+    initCurrentTour(null);
+  } else {
+    initCurrentTour(currentTour);
   }
-
-
-  export function setGuidedTourState(isGuidedTourDisabled, initCurrentTour, currentTour, guidedTourProperties ) {
-    const cookieName = guidedTourProperties.find((tour) => tour.name === currentTour)?.cookieName || "tourGuide";
-    sessionStorage.setItem(cookieName + "Disabled", isGuidedTourDisabled);
-    if (isGuidedTourDisabled) {
-      initCurrentTour(null);
-    } else {
-      initCurrentTour(currentTour);
-    }
-  }
+}


### PR DESCRIPTION
## What

The 'Don't show again' checkbox on guided-tour popups appeared to do nothing — dismiss a tour, reload the page, the popup is back. This PR makes the dismissal actually stick (and survive closing/reopening the browser).

## Root cause — three compounding bugs in the guided-tour module

1. **`GuidedTour.jsx:28` used `||` where it should have been `&&`.**

2. **`initGuidedTourState()` clobbered the dismissal on every page mount.**
   Called unconditionally from `Projects`, `Home`, `ModelCatalog`, `LabelingTool`, etc., with a default `value = true`. It would overwrite `localStorage[name+'Disabled']` to `'true'` (disabled) on every mount, so the per-tour state was reset before the visibility check could read it. Reworked into a true initializer: only writes the entry when no value exists yet, and the default is now `false` (not disabled).

3. **`validateIsGuidedTourDisabled()` treated `null` as 'disabled'.**
   A first-time visitor (no storage entry) looked identical to a user who had explicitly clicked 'Don't show again'. The `||` in bug 1 was the workaround that forced the tour to show anyway, which is what broke the dismissal. Now only the literal string `'true'` counts as dismissed.

The three together created a system where the per-tour dismissal was structurally impossible to observe — even though the click handler wrote the right value.

## Bonus fix — `sessionStorage` → `localStorage`

The per-tour entry was in `sessionStorage`, which is wiped when the tab is closed. The natural expectation for 'Don't show again' is that it survives closing and reopening the browser; switched to `localStorage`. The helper's existing `cookieName` naming already suggested an original intent of persistent storage.

## One small tightening

`GuidedTour.jsx`'s useEffect only ever did `setIsVisible(true)` (never `false`), so when one tour ended and another (already-dismissed) one started, the stale `isVisible=true` could briefly leak into the next tour's render. Replaced with an unconditional `setIsVisible(shouldShow)`.

## Verification

- `pre-commit` clean (only `detect-secrets` applies to UI files; the python hooks are scoped to api/hastelib/docker/training/code).
- `docker compose build ui && up -d --force-recreate ui` — Vite 8 starts cleanly, SWA emulator reachable on 4280 → 302.

Manual test (recommended on review):
1. Visit any page with a guided tour (e.g. /projects).
2. Click 'Don't show again' on the bubble.
3. Reload the page (F5). Bubble should stay dismissed.
4. Close and reopen the tab/browser. Bubble should still be dismissed.
5. Click the '?' button in the header. Bubble should reappear (Help re-enables it).

## Files changed

- `ui/src/Components/GuidedTour.jsx` — `||` → `&&`, explicit `setIsVisible(shouldShow)`.
- `ui/src/Components/GuidedTourHelper.js` — rewrote the three exported helpers + storage backend.