### PR TITLE
V marcelod/feat validation report and ux fluentui 8 implementation

### DIFF
--- a/ui/src/Components/BuildingValidation/AssessmentReportModal.jsx
+++ b/ui/src/Components/BuildingValidation/AssessmentReportModal.jsx
@@ -2,124 +2,148 @@
 // Licensed under the MIT License.
 import { useEffect, useState } from "react";
 import { Dialog, DialogType, DialogFooter } from "@fluentui/react/lib/Dialog";
-import { DefaultButton, Spinner, SpinnerSize, Text } from "@fluentui/react";
+import {
+  DefaultButton,
+  PrimaryButton,
+  Spinner,
+  SpinnerSize,
+  Text,
+  Icon,
+  Stack,
+  MessageBar,
+  MessageBarType,
+  mergeStyles,
+} from "@fluentui/react";
 import PropTypes from "prop-types";
 import { apiGet } from "../../util/api";
 
-// ─── Small presentational helpers ─────────────────────────────────────────
+/* ── Fluent v8 design tokens ─────────────────────────────────── */
+const tokens = {
+  colorNeutralBackground1: "#ffffff",
+  colorNeutralBackground2: "#faf9f8",
+  colorNeutralForeground1: "#242424",
+  colorNeutralForeground2: "#424242",
+  colorNeutralForeground3: "#616161",
+  colorNeutralStroke1: "#d1d1d1",
+  colorNeutralStroke2: "#e0e0e0",
+  colorBrandForeground1: "#0f6cbd",
+  colorSuccessForeground1: "#107C10",
+  colorDangerForeground1: "#C50F1F",
+  spacingS: 4,
+  spacingM: 8,
+  borderRadius: 4,
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
 
 const pct = (v) => (v == null ? "—" : `${(v * 100).toFixed(1)}%`);
 const int = (v) => (v == null ? "—" : Math.round(v).toLocaleString());
 const num = (v, d = 4) => (v == null ? "—" : Number(v).toFixed(d));
 
-const MetricRow = ({ label, value }) => (
-  <tr>
-    <td style={{ padding: "4px 12px 4px 0", fontWeight: 500, color: "#444" }}>
-      {label}
-    </td>
-    <td style={{ padding: "4px 0", fontFamily: "monospace" }}>{value}</td>
-  </tr>
+/* ── Styles ──────────────────────────────────────────────────── */
+const metricCardClass = mergeStyles({
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  padding: "8px 12px",
+  borderRadius: tokens.borderRadius,
+  background: tokens.colorNeutralBackground2,
+  border: `1px solid ${tokens.colorNeutralStroke2}`,
+});
+
+const heroCardBase = mergeStyles({
+  flex: 1,
+  padding: "12px 16px",
+  borderRadius: tokens.borderRadius,
+  background: tokens.colorNeutralBackground2,
+  border: `1px solid ${tokens.colorNeutralStroke2}`,
+});
+
+const halfItemStyles = { root: { minWidth: 0, flexBasis: "50%", maxWidth: "50%" } };
+
+/* ── Sub-components ──────────────────────────────────────────── */
+const SectionTitle = ({ children }) => (
+  <Text variant="medium" styles={{ root: { fontWeight: 600, color: tokens.colorNeutralForeground1, display: "block", marginBottom: tokens.spacingM } }}>
+    {children}
+  </Text>
 );
-MetricRow.propTypes = {
+SectionTitle.propTypes = { children: PropTypes.node.isRequired };
+
+const MetricCard = ({ label, value, accent }) => (
+  <div className={metricCardClass}>
+    <Text variant="small" styles={{ root: { color: tokens.colorNeutralForeground3 } }}>{label}</Text>
+    <Text variant="medium" styles={{ root: { fontWeight: 600, color: accent || tokens.colorNeutralForeground1 } }}>
+      {value}
+    </Text>
+  </div>
+);
+MetricCard.propTypes = {
   label: PropTypes.string.isRequired,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  accent: PropTypes.string,
 };
 
-// ─── Precision-recall sparkline (no extra deps; tiny inline SVG) ──────────
+const HeroCard = ({ label, value, color }) => (
+  <div className={heroCardBase}>
+    <Text variant="small" styles={{ root: { color: tokens.colorNeutralForeground3, display: "block", marginBottom: 10 } }}>
+      {label}
+    </Text>
+    <Text variant="xxLarge" styles={{ root: { fontWeight: 600, color, lineHeight: 1 } }}>
+      {value}
+    </Text>
+  </div>
+);
+HeroCard.propTypes = {
+  label: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  color: PropTypes.string.isRequired,
+};
+
+// ─── Precision-recall chart (full width SVG) ──────────────────────────────
 
 const PrecisionRecallChart = ({ precision, recall }) => {
   if (!precision || !recall || precision.length === 0) return null;
-  const w = 360;
-  const h = 200;
-  const pad = 28;
-  const xScale = (r) => pad + r * (w - 2 * pad);
-  const yScale = (p) => h - pad - p * (h - 2 * pad);
-  // recall/precision arrive from the server in PR-curve order (descending
-  // threshold); for a clean monotone-ish polyline, sort by ascending recall.
+  const h = 180;
+  const pad = 32;
+  const w = 400;
   const points = recall
     .map((r, i) => [r, precision[i]])
-    .sort((a, b) => a[0] - b[0])
-    .map(([r, p]) => `${xScale(r).toFixed(1)},${yScale(p).toFixed(1)}`)
-    .join(" ");
+    .sort((a, b) => a[0] - b[0]);
   const ticks = [0, 0.25, 0.5, 0.75, 1.0];
   return (
-    <svg
-      width={w}
-      height={h}
-      role="img"
-      aria-label="Precision-recall curve"
-      style={{ border: "1px solid #dee2e6", borderRadius: 4 }}
-    >
-      {/* Axes */}
-      <line x1={pad} y1={h - pad} x2={w - pad} y2={h - pad} stroke="#999" />
-      <line x1={pad} y1={pad} x2={pad} y2={h - pad} stroke="#999" />
-      {/* Gridlines + tick labels */}
-      {ticks.map((t) => (
-        <g key={`x-${t}`}>
-          <line
-            x1={xScale(t)}
-            y1={pad}
-            x2={xScale(t)}
-            y2={h - pad}
-            stroke="#eee"
-          />
-          <text
-            x={xScale(t)}
-            y={h - pad + 12}
-            fontSize="10"
-            fill="#666"
-            textAnchor="middle"
-          >
-            {t.toFixed(2)}
-          </text>
-        </g>
-      ))}
-      {ticks.map((t) => (
-        <g key={`y-${t}`}>
-          <line
-            x1={pad}
-            y1={yScale(t)}
-            x2={w - pad}
-            y2={yScale(t)}
-            stroke="#eee"
-          />
-          <text
-            x={pad - 4}
-            y={yScale(t) + 3}
-            fontSize="10"
-            fill="#666"
-            textAnchor="end"
-          >
-            {t.toFixed(2)}
-          </text>
-        </g>
-      ))}
-      <text
-        x={w / 2}
-        y={h - 4}
-        fontSize="11"
-        fill="#444"
-        textAnchor="middle"
+    <div style={{ maxWidth: 480, margin: "0 auto" }}>
+      <svg
+        width="100%"
+        viewBox={`0 0 ${w} ${h}`}
+        preserveAspectRatio="xMidYMid meet"
+        role="img"
+        aria-label="Precision-recall curve"
+        style={{ border: `1px solid ${tokens.colorNeutralStroke2}`, borderRadius: tokens.borderRadius, display: "block" }}
       >
-        Recall (damaged)
-      </text>
-      <text
-        x={10}
-        y={h / 2}
-        fontSize="11"
-        fill="#444"
-        textAnchor="middle"
-        transform={`rotate(-90 10 ${h / 2})`}
-      >
-        Precision (damaged)
-      </text>
-      <polyline
-        points={points}
-        fill="none"
-        stroke="#0078D4"
-        strokeWidth="1.5"
-      />
-    </svg>
+        <line x1={pad} y1={h - pad} x2={w - pad} y2={h - pad} stroke={tokens.colorNeutralStroke1} />
+        <line x1={pad} y1={pad} x2={pad} y2={h - pad} stroke={tokens.colorNeutralStroke1} />
+        {ticks.map((t) => {
+          const x = pad + t * (w - 2 * pad);
+          const y = h - pad - t * (h - 2 * pad);
+          return (
+            <g key={`t-${t}`}>
+              <line x1={x} y1={pad} x2={x} y2={h - pad} stroke={tokens.colorNeutralStroke2} />
+              <line x1={pad} y1={y} x2={w - pad} y2={y} stroke={tokens.colorNeutralStroke2} />
+              <text x={x} y={h - pad + 13} fontSize="9" fill={tokens.colorNeutralForeground3} textAnchor="middle">{t.toFixed(2)}</text>
+              <text x={pad - 5} y={y + 3} fontSize="9" fill={tokens.colorNeutralForeground3} textAnchor="end">{t.toFixed(2)}</text>
+            </g>
+          );
+        })}
+        <text x={w / 2} y={h - 4} fontSize="10" fill={tokens.colorNeutralForeground2} textAnchor="middle">Recall (damaged)</text>
+        <text x={10} y={h / 2} fontSize="10" fill={tokens.colorNeutralForeground2} textAnchor="middle" transform={`rotate(-90 10 ${h / 2})`}>Precision (damaged)</text>
+        <polyline
+          points={points.map(([r, p]) => `${(pad + r * (w - 2 * pad)).toFixed(1)},${(h - pad - p * (h - 2 * pad)).toFixed(1)}`).join(" ")}
+          fill="none"
+          stroke={tokens.colorBrandForeground1}
+          strokeWidth="2"
+        />
+      </svg>
+    </div>
   );
 };
 PrecisionRecallChart.propTypes = {
@@ -148,13 +172,15 @@ const AssessmentReportModal = ({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  useEffect(() => {
+  const fetchReport = () => {
+    setLoading(true);
+    setError(null);
+    setReport(null);
     apiGet(
       `GetAssessmentReport?projectId=${projectId}&imageLayerId=${imageLayerId}&modelId=${modelId}`
     )
       .then((data) => {
         if (data && data.error && !data.predictions) {
-          // Hard error from the server (no inference / no footprints).
           setError(data.error);
         } else {
           setReport(data);
@@ -162,6 +188,10 @@ const AssessmentReportModal = ({
       })
       .catch(() => setError("Failed to load assessment report."))
       .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    fetchReport();
   }, [projectId, imageLayerId, modelId]);
 
   const preds = report?.predictions;
@@ -170,7 +200,6 @@ const AssessmentReportModal = ({
   const sample = report?.evaluationSample;
   const hasLabels = (report?.matched ?? 0) > 0;
 
-  // One-paragraph summary, modeled on the CLI script.
   function buildSummarySentence() {
     if (!report || !preds) return "";
     let s =
@@ -209,130 +238,142 @@ const AssessmentReportModal = ({
       onDismiss={onDismiss}
       dialogContentProps={{
         type: DialogType.largeHeader,
-        title: `Assessment Report — ${modelName || modelId}`,
-        subText: loading ? "Computing…" : error ? error : summarySentence,
+        title: (
+          <Stack horizontal verticalAlign="center" tokens={{ childrenGap: 8 }}>
+            <Icon iconName="AnalyticsReport" styles={{ root: { fontSize: 20, color: tokens.colorBrandForeground1 } }} />
+            <span>{`Assessment Report — ${modelName || modelId}`}</span>
+          </Stack>
+        ),
+        subText: loading ? undefined : error ? undefined : summarySentence,
       }}
       modalProps={{ isBlocking: false }}
-      minWidth={620}
+      minWidth={860}
     >
       {loading && (
-        <div style={{ padding: "24px 0", textAlign: "center" }}>
+        <Stack horizontalAlign="center" styles={{ root: { padding: "32px 0" } }}>
           <Spinner size={SpinnerSize.large} label="Computing assessment…" />
-        </div>
+        </Stack>
       )}
 
       {!loading && error && (
-        <div style={{ padding: "16px 0", color: "#a4000f" }}>
-          <Text>{error}</Text>
-        </div>
+        <MessageBar messageBarType={MessageBarType.error} isMultiline={false}>
+          {error}
+        </MessageBar>
       )}
 
       {!loading && report && !error && (
-        <div style={{ padding: "4px 0 16px" }}>
-          {/* Predictions section */}
-          <Text
-            variant="mediumPlus"
-            style={{ fontWeight: 600, display: "block", marginBottom: 8 }}
-          >
-            Predictions
-          </Text>
-          <table style={{ marginBottom: 16 }}>
-            <tbody>
-              <MetricRow label="Buildings with a prediction" value={int(preds.total)} />
-              <MetricRow label="Non-cloudy" value={int(preds.knownNonCloudy)} />
-              <MetricRow label="Cloud-covered (excluded)" value={int(preds.cloudy)} />
-              <MetricRow
-                label={`Predicted damaged (> ${report.threshold})`}
-                value={`${int(preds.predictedDamaged)} (${preds.predictedDamagedPctOfKnown ?? 0}% of non-cloudy)`}
-              />
-            </tbody>
-          </table>
+        <Stack tokens={{ childrenGap: 24 }}>
+          {/* Predictions — 2 columns, 2 per row */}
+          <div>
+            <SectionTitle>Predictions</SectionTitle>
+            <Stack tokens={{ childrenGap: tokens.spacingS }}>
+              <Stack horizontal tokens={{ childrenGap: tokens.spacingS }}>
+                <Stack.Item grow={1} styles={halfItemStyles}>
+                  <MetricCard label="Buildings with a prediction" value={int(preds?.total)} />
+                </Stack.Item>
+                <Stack.Item grow={1} styles={halfItemStyles}>
+                  <MetricCard label="Non-cloudy" value={int(preds?.knownNonCloudy)} />
+                </Stack.Item>
+              </Stack>
+              <Stack horizontal tokens={{ childrenGap: tokens.spacingS }}>
+                <Stack.Item grow={1} styles={halfItemStyles}>
+                  <MetricCard label="Cloud-covered (excluded)" value={int(preds?.cloudy)} />
+                </Stack.Item>
+                <Stack.Item grow={1} styles={halfItemStyles}>
+                  <MetricCard label={`Predicted damaged (> ${report.threshold})`} value={`${int(preds?.predictedDamaged)} (${preds?.predictedDamagedPctOfKnown ?? 0}% of non-cloudy)`} accent={tokens.colorDangerForeground1} />
+                </Stack.Item>
+              </Stack>
+            </Stack>
+          </div>
 
-          {/* Population estimate */}
-          <Text
-            variant="mediumPlus"
-            style={{ fontWeight: 600, display: "block", marginBottom: 8 }}
-          >
-            Damaged-building population estimate
-          </Text>
-          <table style={{ marginBottom: 16 }}>
-            <tbody>
-              <MetricRow
-                label={`N (buildings with area > ${pop?.minAreaM2?.toFixed(0)} m²)`}
-                value={int(pop?.N)}
-              />
-              <MetricRow label="Sample size (n)" value={int(pop?.n)} />
-              <MetricRow label="Damaged in sample (x)" value={int(pop?.x)} />
-              <MetricRow label="Sample damage rate (p̂)" value={pct(pop?.pHat)} />
-              <MetricRow label="Sampling fraction (n/N)" value={num(pop?.samplingFraction, 6)} />
-              <MetricRow label="Std. error of p̂" value={num(pop?.sePHat, 6)} />
-              <MetricRow
-                label="Estimated damaged buildings (Ŷ)"
-                value={int(pop?.estimatedDamaged)}
-              />
-              <MetricRow
-                label="95% CI"
-                value={
-                  pop?.ciLower != null && pop?.ciUpper != null
-                    ? `[${int(pop.ciLower)}, ${int(pop.ciUpper)}]`
-                    : "—"
-                }
-              />
-            </tbody>
-          </table>
+          {/* Population estimate — 2 columns, 2 per row */}
+          <div>
+            <SectionTitle>Damaged-building population estimate</SectionTitle>
+            <Stack tokens={{ childrenGap: tokens.spacingS }}>
+              <Stack horizontal tokens={{ childrenGap: tokens.spacingS }}>
+                <Stack.Item grow={1} styles={halfItemStyles}>
+                  <MetricCard label={`N (buildings with area > ${pop?.minAreaM2?.toFixed(0)} m²)`} value={int(pop?.N)} />
+                </Stack.Item>
+                <Stack.Item grow={1} styles={halfItemStyles}>
+                  <MetricCard label="Sample size (n)" value={int(pop?.n)} />
+                </Stack.Item>
+              </Stack>
+              <Stack horizontal tokens={{ childrenGap: tokens.spacingS }}>
+                <Stack.Item grow={1} styles={halfItemStyles}>
+                  <MetricCard label="Damaged in sample (x)" value={int(pop?.x)} />
+                </Stack.Item>
+                <Stack.Item grow={1} styles={halfItemStyles}>
+                  <MetricCard label="Sample damage rate (p̂)" value={pct(pop?.pHat)} accent={tokens.colorDangerForeground1} />
+                </Stack.Item>
+              </Stack>
+              <Stack horizontal tokens={{ childrenGap: tokens.spacingS }}>
+                <Stack.Item grow={1} styles={halfItemStyles}>
+                  <MetricCard label="Sampling fraction (n/N)" value={num(pop?.samplingFraction, 6)} />
+                </Stack.Item>
+                <Stack.Item grow={1} styles={halfItemStyles}>
+                  <MetricCard label="Std. error of p̂" value={num(pop?.sePHat, 6)} />
+                </Stack.Item>
+              </Stack>
+              <Stack horizontal tokens={{ childrenGap: tokens.spacingS }}>
+                <Stack.Item grow={1} styles={halfItemStyles}>
+                  <MetricCard label="Estimated damaged buildings (Ŷ)" value={int(pop?.estimatedDamaged)} accent={tokens.colorDangerForeground1} />
+                </Stack.Item>
+                <Stack.Item grow={1} styles={halfItemStyles}>
+                  <MetricCard label="95% CI" value={pop?.ciLower != null && pop?.ciUpper != null ? `[${int(pop.ciLower)}, ${int(pop.ciUpper)}]` : "—"} />
+                </Stack.Item>
+              </Stack>
+            </Stack>
+          </div>
 
           {/* Metrics & PR curve — only when labels exist */}
           {hasLabels && (
             <>
-              <Text
-                variant="mediumPlus"
-                style={{ fontWeight: 600, display: "block", marginBottom: 8 }}
-              >
-                Binary metrics (positive class = Damaged)
-              </Text>
-              <table style={{ marginBottom: 16 }}>
-                <tbody>
-                  <MetricRow label="Accuracy" value={pct(metrics?.accuracy)} />
-                  <MetricRow label="Precision" value={pct(metrics?.precision)} />
-                  <MetricRow label="Recall" value={pct(metrics?.recall)} />
-                  <MetricRow
-                    label="Average precision"
-                    value={pct(metrics?.averagePrecision)}
-                  />
-                  <MetricRow label="Matched sample" value={int(sample?.n)} />
-                  <MetricRow
-                    label="True damaged / not damaged"
-                    value={`${int(sample?.trueDamaged)} / ${int(sample?.trueNotDamaged)}`}
-                  />
-                </tbody>
-              </table>
-
+              {/* Binary metrics — 2 columns, 2 per row */}
+              <div>
+                <SectionTitle>Binary metrics (positive class = Damaged)</SectionTitle>
+                <Stack tokens={{ childrenGap: tokens.spacingS }}>
+                  <Stack horizontal tokens={{ childrenGap: tokens.spacingS }}>
+                    <Stack.Item grow={1} styles={halfItemStyles}>
+                      <MetricCard label="Accuracy" value={pct(metrics?.accuracy)} />
+                    </Stack.Item>
+                    <Stack.Item grow={1} styles={halfItemStyles}>
+                      <MetricCard label="Precision" value={pct(metrics?.precision)} />
+                    </Stack.Item>
+                  </Stack>
+                  <Stack horizontal tokens={{ childrenGap: tokens.spacingS }}>
+                    <Stack.Item grow={1} styles={halfItemStyles}>
+                      <MetricCard label="Recall" value={pct(metrics?.recall)} />
+                    </Stack.Item>
+                    <Stack.Item grow={1} styles={halfItemStyles}>
+                      <MetricCard label="Average precision" value={pct(metrics?.averagePrecision)} />
+                    </Stack.Item>
+                  </Stack>
+                  <Stack horizontal tokens={{ childrenGap: tokens.spacingS }}>
+                    <Stack.Item grow={1} styles={halfItemStyles}>
+                      <MetricCard label="Matched sample" value={int(sample?.n)} />
+                    </Stack.Item>
+                    <Stack.Item grow={1} styles={halfItemStyles}>
+                      <MetricCard label="True damaged / not damaged" value={`${int(sample?.trueDamaged)} / ${int(sample?.trueNotDamaged)}`} />
+                    </Stack.Item>
+                  </Stack>
+                </Stack>
+              </div>
               {sample?.hasBothClasses === false && (
-                <Text
-                  variant="small"
-                  style={{ color: "#8a6d3b", display: "block", marginBottom: 8 }}
-                >
-                  Note: the labeled sample contains only one class; metrics may
-                  be degenerate.
-                </Text>
+                <MessageBar messageBarType={MessageBarType.warning} isMultiline={false}>
+                  The labeled sample contains only one class; metrics may be degenerate.
+                </MessageBar>
               )}
 
-              <Text
-                variant="mediumPlus"
-                style={{ fontWeight: 600, display: "block", marginBottom: 8 }}
-              >
-                Precision-recall curve
-              </Text>
-              <PrecisionRecallChart
-                precision={report.precisionRecallCurve?.precision}
-                recall={report.precisionRecallCurve?.recall}
-              />
+              <div>
+                <SectionTitle>Precision-recall curve</SectionTitle>
+                <PrecisionRecallChart
+                  precision={report.precisionRecallCurve?.precision}
+                  recall={report.precisionRecallCurve?.recall}
+                />
+              </div>
 
               {report.labeledMissingFromPredictions > 0 && (
-                <Text
-                  variant="small"
-                  style={{ color: "#666", display: "block", marginTop: 12 }}
-                >
+                <Text variant="small" styles={{ root: { color: tokens.colorNeutralForeground3 } }}>
                   {report.labeledMissingFromPredictions} sure label
                   {report.labeledMissingFromPredictions === 1 ? "" : "s"} had
                   no matching prediction and were dropped.
@@ -340,10 +381,11 @@ const AssessmentReportModal = ({
               )}
             </>
           )}
-        </div>
+        </Stack>
       )}
 
       <DialogFooter>
+        {error && <PrimaryButton onClick={fetchReport} text="Retry" />}
         <DefaultButton onClick={onDismiss} text="Close" />
       </DialogFooter>
     </Dialog>

--- a/ui/src/Components/BuildingValidation/BuildingValidation.jsx
+++ b/ui/src/Components/BuildingValidation/BuildingValidation.jsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { ActionButton } from "@fluentui/react";
 import { useEffect, useMemo, useRef, useState, useContext } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { apiGet, apiPut } from "../../util/api";
@@ -7,6 +8,7 @@ import { getAzureMapsAuthOptions, isAzureMapsPlaceholder } from "../../util/azur
 import { AppContext } from "../../AppContext.jsx";
 import BuildingValidationRightPanel from "./BuildingValidationRightPanel.jsx";
 import { loadImagery } from "../LabelingTool/LabelingToolHelper.js";
+import "../../assets/css/labels.css";
 
 const LABEL_COLORS = {
   Damaged: "#e74c3c",
@@ -529,24 +531,17 @@ const BuildingValidation = () => {
 
   return (
     <div style={{ display: "flex", flexGrow: 1, position: "relative", overflow: "hidden" }}>
-      {/* Back button */}
-      <button
-        onClick={() => navigate(`/project/${projectId}`)}
-        style={{
-          position: "absolute",
-          top: 12,
-          left: 12,
-          zIndex: 1000,
-          background: "rgba(255,255,255,0.9)",
-          border: "1px solid #ccc",
-          borderRadius: 4,
-          padding: "6px 14px",
-          cursor: "pointer",
-          fontWeight: 500,
-        }}
-      >
-        ← Back to Project
-      </button>
+      {/* Back button — matches Visualizer styling */}
+      <div className="absolute-labels pre-disaster d-flex flex-column labels-back-button">
+        <ActionButton
+          id="backButton"
+          iconProps={{ iconName: "ChevronLeft" }}
+          className="w-100 p-0 m-0"
+          onClick={() => navigate(`/project/${projectId}`)}
+        >
+          Back
+        </ActionButton>
+      </div>
 
       {/* Map container */}
       <div ref={mapContainerRef} id="validationMap" style={{ flexGrow: 1 }} />

--- a/ui/src/Components/BuildingValidation/ValidationReportModal.jsx
+++ b/ui/src/Components/BuildingValidation/ValidationReportModal.jsx
@@ -2,87 +2,184 @@
 // Licensed under the MIT License.
 import { useEffect, useState } from "react";
 import { Dialog, DialogType, DialogFooter } from "@fluentui/react/lib/Dialog";
-import { DefaultButton, Spinner, SpinnerSize, Text } from "@fluentui/react";
+import {
+  DefaultButton,
+  PrimaryButton,
+  Spinner,
+  SpinnerSize,
+  Text,
+  Icon,
+  Stack,
+  MessageBar,
+  MessageBarType,
+  mergeStyles,
+} from "@fluentui/react";
 import PropTypes from "prop-types";
 import { apiGet } from "../../util/api";
 
+/* ── Fluent v8 design tokens ─────────────────────────────────── */
+const tokens = {
+  colorNeutralBackground1: "#ffffff",
+  colorNeutralBackground2: "#faf9f8",
+  colorNeutralBackground3: "#f3f2f1",
+  colorNeutralForeground1: "#242424",
+  colorNeutralForeground2: "#424242",
+  colorNeutralForeground3: "#616161",
+  colorNeutralStroke1: "#d1d1d1",
+  colorNeutralStroke2: "#e0e0e0",
+  colorBrandBackground: "#0f6cbd",
+  colorBrandForeground1: "#0f6cbd",
+  colorBrandBackground2: "#ebf3fc",
+  colorSuccessBackground1: "#f1faf1",
+  colorSuccessForeground1: "#107C10",
+  colorDangerBackground1: "#fdf3f4",
+  colorDangerForeground1: "#C50F1F",
+  colorSuccessTint30: "#54B054",
+  colorDangerTint30: "#DC626D",
+  colorNeutralForegroundInverted: "#ffffff",
+  spacingS: 4,
+  spacingM: 8,
+  spacingL: 16,
+  borderRadius: 4,
+};
+
 const pct = (v) => (v != null ? `${(v * 100).toFixed(1)}%` : "—");
 
-const MetricRow = ({ label, value }) => (
-  <tr>
-    <td style={{ padding: "4px 12px 4px 0", fontWeight: 500, color: "#444" }}>{label}</td>
-    <td style={{ padding: "4px 0", fontFamily: "monospace" }}>{value}</td>
-  </tr>
+/* ── Styles ──────────────────────────────────────────────────── */
+const metricCardClass = mergeStyles({
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  padding: "8px 12px",
+  borderRadius: tokens.borderRadius,
+  background: tokens.colorNeutralBackground2,
+  border: `1px solid ${tokens.colorNeutralStroke2}`,
+});
+
+const heroCardBase = mergeStyles({
+  flex: 1,
+  padding: "12px 16px",
+  borderRadius: tokens.borderRadius,
+  background: tokens.colorNeutralBackground2,
+  border: `1px solid ${tokens.colorNeutralStroke2}`,
+});
+
+/* ── Sub-components ──────────────────────────────────────────── */
+const SectionTitle = ({ children }) => (
+  <Text variant="medium" styles={{ root: { fontWeight: 600, color: tokens.colorNeutralForeground1, display: "block", marginBottom: tokens.spacingM } }}>
+    {children}
+  </Text>
 );
-MetricRow.propTypes = { label: PropTypes.string.isRequired, value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired };
+SectionTitle.propTypes = { children: PropTypes.node.isRequired };
+
+const MetricCard = ({ label, value, accent }) => (
+  <div className={metricCardClass}>
+    <Text variant="small" styles={{ root: { color: tokens.colorNeutralForeground3 } }}>{label}</Text>
+    <Text variant="medium" styles={{ root: { fontWeight: 600, color: accent || tokens.colorNeutralForeground1 } }}>
+      {value}
+    </Text>
+  </div>
+);
+MetricCard.propTypes = {
+  label: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  accent: PropTypes.string,
+};
+
+const HeroCard = ({ label, value, color }) => (
+  <div className={heroCardBase}>
+    <Text variant="small" styles={{ root: { color: tokens.colorNeutralForeground3, display: "block", marginBottom: 10 } }}>
+      {label}
+    </Text>
+    <Text variant="xxLarge" styles={{ root: { fontWeight: 600, color, lineHeight: 1 } }}>
+      {value}
+    </Text>
+  </div>
+);
+HeroCard.propTypes = {
+  label: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  color: PropTypes.string.isRequired,
+};
+
+const thStyle = {
+  padding: "8px",
+  textAlign: "left",
+  borderBottom: `2px solid ${tokens.colorNeutralStroke1}`,
+  color: tokens.colorNeutralForeground3,
+  fontSize: 12,
+  fontWeight: 600,
+};
 
 const ConfusionMatrix = ({ matrix, labels }) => {
-  const cellStyle = (i, j) => ({
-    padding: "8px 14px",
-    textAlign: "center",
-    fontFamily: "monospace",
-    fontSize: 14,
-    background: i === j ? "#d4edda" : "#f8d7da",
-    border: "1px solid #dee2e6",
-    fontWeight: i === j ? 700 : 400,
-  });
-  const headerStyle = {
-    padding: "6px 14px",
+  const total = matrix.flat().reduce((a, b) => a + b, 0);
+  const cellStyle = (i, j, val) => {
+    const intensity = total > 0 ? Math.min(val / total * 4, 1) : 0;
+    const isCorrect = i === j;
+    return {
+      padding: "10px",
+      textAlign: "center",
+      fontSize: 14,
+      fontWeight: 600,
+      background: isCorrect ? tokens.colorSuccessTint30 : val > 0 ? tokens.colorDangerTint30 : tokens.colorNeutralBackground2,
+      border: `1px solid ${tokens.colorNeutralStroke2}`,
+      color: isCorrect || val > 0 ? tokens.colorNeutralForegroundInverted : tokens.colorNeutralForeground3,
+    };
+  };
+  const hdr = {
+    padding: "8px 10px",
     textAlign: "center",
     fontSize: 12,
-    color: "#666",
-    border: "1px solid #dee2e6",
-    background: "#f5f5f5",
+    fontWeight: 600,
+    color: tokens.colorNeutralForeground3,
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    background: tokens.colorNeutralBackground2,
   };
   return (
-    <div style={{ overflowX: "auto", marginTop: 8 }}>
-      <table style={{ borderCollapse: "collapse", fontSize: 13 }}>
-        <thead>
-          <tr>
-            <th style={{ ...headerStyle, background: "transparent", border: "none" }} />
-            <th colSpan={labels.length} style={{ ...headerStyle, background: "#e8f4fd", border: "1px solid #dee2e6" }}>
-              Predicted
-            </th>
-          </tr>
-          <tr>
-            <th style={{ ...headerStyle, background: "transparent", border: "none" }} />
-            {labels.map((l) => (
-              <th key={l} style={headerStyle}>{l}</th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {matrix.map((row, i) => (
-            <tr key={i}>
-              {i === 0 && (
-                <td
-                  rowSpan={matrix.length}
-                  style={{
-                    ...headerStyle,
-                    background: "#e8f4fd",
-                    writingMode: "vertical-rl",
-                    transform: "rotate(180deg)",
-                    textAlign: "center",
-                    fontWeight: 600,
-                    padding: "8px 4px",
-                    border: "1px solid #dee2e6",
-                  }}
-                >
-                  Actual
-                </td>
-              )}
-              <td style={{ ...headerStyle }}>{labels[i]}</td>
-              {row.map((val, j) => (
-                <td key={j} style={cellStyle(i, j)}>{val}</td>
-              ))}
+    <Stack tokens={{ childrenGap: tokens.spacingM }}>
+      <div style={{ overflowX: "auto" }}>
+        <table style={{ borderCollapse: "collapse", width: "100%" }}>
+          <thead>
+            <tr>
+              <th style={{ ...hdr, background: "transparent", border: "none" }} />
+              <th colSpan={labels.length} style={{ ...hdr, background: tokens.colorBrandBackground2, color: tokens.colorBrandForeground1 }}>
+                Predicted
+              </th>
             </tr>
-          ))}
-        </tbody>
-      </table>
-      <Text variant="xSmall" style={{ color: "#888", marginTop: 4, display: "block" }}>
-        Green = correct predictions, Red = misclassifications
-      </Text>
-    </div>
+            <tr>
+              <th style={{ ...hdr, background: "transparent", border: "none" }} />
+              {labels.map((l) => <th key={l} style={{ ...hdr, color: tokens.colorNeutralForeground1 }}>{l}</th>)}
+            </tr>
+          </thead>
+          <tbody>
+            {matrix.map((row, i) => (
+              <tr key={i}>
+                {i === 0 && (
+                  <td rowSpan={matrix.length} style={{
+                    ...hdr, background: tokens.colorBrandBackground2, color: tokens.colorBrandForeground1,
+                    writingMode: "vertical-rl", transform: "rotate(180deg)", padding: "8px 4px",
+                  }}>
+                    Actual
+                  </td>
+                )}
+                <td style={{ ...hdr, color: tokens.colorNeutralForeground1 }}>{labels[i]}</td>
+                {row.map((val, j) => <td key={j} style={cellStyle(i, j, val)}>{val}</td>)}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <Stack horizontal tokens={{ childrenGap: tokens.spacingL }} horizontalAlign="start">
+        <Stack horizontal verticalAlign="center" tokens={{ childrenGap: tokens.spacingS }}>
+          <div style={{ width: 10, height: 10, borderRadius: 2, background: tokens.colorSuccessTint30 }} />
+          <Text variant="xSmall" styles={{ root: { color: tokens.colorNeutralForeground3 } }}>Correct</Text>
+        </Stack>
+        <Stack horizontal verticalAlign="center" tokens={{ childrenGap: tokens.spacingS }}>
+          <div style={{ width: 10, height: 10, borderRadius: 2, background: tokens.colorDangerTint30 }} />
+          <Text variant="xSmall" styles={{ root: { color: tokens.colorNeutralForeground3 } }}>Misclassified</Text>
+        </Stack>
+      </Stack>
+    </Stack>
   );
 };
 ConfusionMatrix.propTypes = {
@@ -90,6 +187,7 @@ ConfusionMatrix.propTypes = {
   labels: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
+/* ── Main component ──────────────────────────────────────────── */
 const ValidationReportModal = ({ projectId, imageLayerId, modelId, modelName, onDismiss }) => {
   ValidationReportModal.propTypes = {
     projectId: PropTypes.string.isRequired,
@@ -103,7 +201,10 @@ const ValidationReportModal = ({ projectId, imageLayerId, modelId, modelName, on
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  useEffect(() => {
+  const fetchReport = () => {
+    setLoading(true);
+    setError(null);
+    setReport(null);
     apiGet(
       `GetValidationReport?projectId=${projectId}&imageLayerId=${imageLayerId}&modelId=${modelId}`
     )
@@ -113,6 +214,10 @@ const ValidationReportModal = ({ projectId, imageLayerId, modelId, modelName, on
       })
       .catch(() => setError("Failed to load validation report."))
       .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    fetchReport();
   }, [projectId, imageLayerId, modelId]);
 
   return (
@@ -121,101 +226,101 @@ const ValidationReportModal = ({ projectId, imageLayerId, modelId, modelName, on
       onDismiss={onDismiss}
       dialogContentProps={{
         type: DialogType.largeHeader,
-        title: `Validation Report — ${modelName || modelId}`,
+        title: (
+          <Stack horizontal verticalAlign="center" tokens={{ childrenGap: 8 }}>
+            <Icon iconName="ReportDocument" styles={{ root: { fontSize: 20, color: tokens.colorBrandForeground1 } }} />
+            <span>{`Validation Report — ${modelName || modelId}`}</span>
+          </Stack>
+        ),
         subText: loading
-          ? "Loading…"
+          ? undefined
           : error
-          ? error
+          ? undefined
           : `${report?.matched} validation labels matched to inference results (Unknown labels excluded)`,
       }}
       modalProps={{ isBlocking: false }}
-      minWidth={520}
+      minWidth={680}
     >
       {loading && (
-        <div style={{ padding: "24px 0", textAlign: "center" }}>
+        <Stack horizontalAlign="center" styles={{ root: { padding: "32px 0" } }}>
           <Spinner size={SpinnerSize.large} label="Computing report…" />
-        </div>
+        </Stack>
       )}
 
       {!loading && error && (
-        <div style={{ padding: "16px 0", color: "#a4000f" }}>
-          <Text>{error}</Text>
-        </div>
+        <MessageBar messageBarType={MessageBarType.error} isMultiline={false}>
+          {error}
+        </MessageBar>
       )}
 
       {!loading && report && !error && (
-        <div style={{ padding: "4px 0 16px" }}>
-          {/* Summary counts */}
-          <Text variant="mediumPlus" style={{ fontWeight: 600, display: "block", marginBottom: 8 }}>
-            Label Summary
-          </Text>
-          <table style={{ marginBottom: 16 }}>
-            <tbody>
-              <MetricRow label="Total validation labels" value={report.totalValidationLabels} />
-              <MetricRow label="Damaged labels" value={report.labelCounts?.Damaged ?? 0} />
-              <MetricRow label="Not Damaged labels" value={report.labelCounts?.NotDamaged ?? 0} />
-              <MetricRow label="Unknown labels (excluded)" value={report.labelCounts?.Unknown ?? 0} />
-              <MetricRow label="Matched to predictions" value={report.matched} />
-            </tbody>
-          </table>
+        <Stack tokens={{ childrenGap: 24 }}>
+          {/* Overall Metrics */}
+          <div>
+            <SectionTitle>Overall Metrics</SectionTitle>
+            <Stack horizontal tokens={{ childrenGap: 12 }}>
+              <HeroCard label="Accuracy" value={pct(report.accuracy)} color={tokens.colorBrandForeground1} />
+              <HeroCard label="Macro F1" value={pct(report.macroF1)} color={tokens.colorSuccessForeground1} />
+            </Stack>
+          </div>
 
-          {/* Overall accuracy */}
-          <Text variant="mediumPlus" style={{ fontWeight: 600, display: "block", marginBottom: 8 }}>
-            Overall Metrics
-          </Text>
-          <table style={{ marginBottom: 16 }}>
-            <tbody>
-              <MetricRow label="Accuracy" value={pct(report.accuracy)} />
-              <MetricRow label="Macro F1" value={pct(report.macroF1)} />
-            </tbody>
-          </table>
+          {/* Two-column layout */}
+          <Stack horizontal tokens={{ childrenGap: 32 }}>
+            <Stack.Item grow={1} styles={{ root: { minWidth: 0 } }}>
+              <SectionTitle>Label Summary</SectionTitle>
+              <Stack tokens={{ childrenGap: tokens.spacingS }}>
+                <MetricCard label="Total validation labels" value={report.totalValidationLabels} />
+                <MetricCard label="Damaged labels" value={report.labelCounts?.Damaged ?? 0} accent={tokens.colorDangerForeground1} />
+                <MetricCard label="Not Damaged labels" value={report.labelCounts?.NotDamaged ?? 0} accent={tokens.colorSuccessForeground1} />
+                <MetricCard label="Unknown labels (excluded)" value={report.labelCounts?.Unknown ?? 0} accent={tokens.colorNeutralForeground3} />
+                <MetricCard label="Matched to predictions" value={report.matched} />
+              </Stack>
+            </Stack.Item>
 
-          {/* Per-class metrics */}
-          <Text variant="mediumPlus" style={{ fontWeight: 600, display: "block", marginBottom: 8 }}>
-            Per-Class Metrics
-          </Text>
-          <table style={{ borderCollapse: "collapse", marginBottom: 16, fontSize: 13, width: "100%" }}>
-            <thead>
-              <tr>
-                {["Class", "Precision", "Recall", "F1"].map((h) => (
-                  <th
-                    key={h}
-                    style={{ padding: "4px 12px", textAlign: "center", borderBottom: "2px solid #dee2e6", color: "#555" }}
-                  >
-                    {h}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {["Damaged", "NotDamaged"].map((cls) => {
-                const m = report.perClass?.[cls];
-                return (
-                  <tr key={cls}>
-                    <td style={{ padding: "4px 12px", fontWeight: 500 }}>{cls === "NotDamaged" ? "Not Damaged" : cls}</td>
-                    <td style={{ padding: "4px 12px", textAlign: "center", fontFamily: "monospace" }}>{pct(m?.precision)}</td>
-                    <td style={{ padding: "4px 12px", textAlign: "center", fontFamily: "monospace" }}>{pct(m?.recall)}</td>
-                    <td style={{ padding: "4px 12px", textAlign: "center", fontFamily: "monospace" }}>{pct(m?.f1)}</td>
+            <Stack.Item grow={1} styles={{ root: { minWidth: 0 } }}>
+              <SectionTitle>Per-Class Metrics</SectionTitle>
+              <table style={{ borderCollapse: "collapse", width: "100%", fontSize: 13 }}>
+                <thead>
+                  <tr>
+                    {["Class", "Precision", "Recall", "F1"].map((h) => (
+                      <th key={h} style={thStyle}>{h}</th>
+                    ))}
                   </tr>
-                );
-              })}
-            </tbody>
-          </table>
+                </thead>
+                <tbody>
+                  {["Damaged", "NotDamaged"].map((cls, idx) => {
+                    const m = report.perClass?.[cls];
+                    return (
+                      <tr key={cls} style={{ background: idx % 2 === 0 ? tokens.colorNeutralBackground2 : tokens.colorNeutralBackground1 }}>
+                        <td style={{ padding: 8, fontWeight: 600, color: tokens.colorNeutralForeground1 }}>
+                          {cls === "NotDamaged" ? "Not Damaged" : cls}
+                        </td>
+                        <td style={{ padding: 8, textAlign: "left", fontWeight: 600 }}>{pct(m?.precision)}</td>
+                        <td style={{ padding: 8, textAlign: "left", fontWeight: 600 }}>{pct(m?.recall)}</td>
+                        <td style={{ padding: 8, textAlign: "left", fontWeight: 600 }}>{pct(m?.f1)}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </Stack.Item>
+          </Stack>
 
-          {/* Confusion matrix */}
-          <Text variant="mediumPlus" style={{ fontWeight: 600, display: "block", marginBottom: 8 }}>
-            Confusion Matrix
-          </Text>
-          {report.confusionMatrix && (
-            <ConfusionMatrix
-              matrix={report.confusionMatrix.matrix}
-              labels={report.confusionMatrix.labels}
-            />
-          )}
-        </div>
+          {/* Confusion matrix full width */}
+          <div>
+            <SectionTitle>Confusion Matrix</SectionTitle>
+            {report.confusionMatrix && (
+              <ConfusionMatrix
+                matrix={report.confusionMatrix.matrix}
+                labels={report.confusionMatrix.labels}
+              />
+            )}
+          </div>
+        </Stack>
       )}
 
       <DialogFooter>
+        {error && <PrimaryButton onClick={fetchReport} text="Retry" />}
         <DefaultButton onClick={onDismiss} text="Close" />
       </DialogFooter>
     </Dialog>


### PR DESCRIPTION
---

## Description

Redesign the Validation Report and Assessment Report modals using Fluent UI v8 components and match the back-button styling to the Visualizer page for a consistent UX across map screens.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Infrastructure / CI change

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My changes follow the project's coding standards (PEP 8 for Python, ESLint rules for JS/TS)
- [ ] I have added or updated tests that cover my changes
- [ ] All existing tests pass locally (`pytest` / `npm test`)
- [ ] I have updated the relevant documentation (README, docs/, inline comments)
- [ ] I have added an entry to [CHANGELOG.md](../CHANGELOG.md) if this is a user-facing change

## Testing

- Verified Validation Report modal renders with Fluent UI components (hero cards, two-column layout, confusion matrix, precision-recall chart)
- Verified Assessment Report modal renders with MetricCard grid (2-column), error/retry states
- Confirmed back button on `/validation/...` matches Visualizer page styling (ActionButton + ChevronLeft icon + `absolute-labels` CSS)

## Additional context

### Changes by file

| File | Change |
|------|--------|
| `ValidationReportModal.jsx` | Replace HTML tables with Fluent UI Stack/Text/MessageBar; add hero cards (Accuracy, Macro F1); two-column layout; confusion matrix with Cranberry/Green color scheme; responsive precision-recall SVG chart; Retry button on error |
| `AssessmentReportModal.jsx` | Replace HTML tables with MetricCard components; 2-column grid layout; semantic color accents; Retry on error; remove duplicate error labels; Segoe UI font |
| `BuildingValidation.jsx` | Replace inline-styled `<button>` with Fluent UI `ActionButton` + `ChevronLeft` icon; reuse Visualizer CSS classes (`absolute-labels`, `pre-disaster`, `labels-back-button`); add `labels.css` import |