### PR TITLE
Mgmachado/fix/deploys for 1.4.6

### DIFF
--- a/.github/scripts/deploy_apps.sh
+++ b/.github/scripts/deploy_apps.sh
@@ -43,6 +43,7 @@ TRAINING_DOCKER_IMAGE="hastetraining:${TRAINING_IMAGE_TAG}"
 IMAGEPREP_DOCKER_IMAGE="hasteimageryprep:${IMAGEPREP_IMAGE_TAG}"
 BATCH_POOL_ID="${RESOURCE_PREFIX}-haste-${RANDOM_SUFFIX}-pool"
 MAPS_ACCOUNT="${RESOURCE_PREFIX}haste${RANDOM_SUFFIX}maps"
+API_MANAGEMENT="${RESOURCE_PREFIX}-haste-${RANDOM_SUFFIX}-apim"
 FIXED_TAGS="project=haste created_by=deploy_apps"
 DYNAMIC_TAGS="env=${ENVIRONMENT} deployed_version=${APP_TAG}"
 EMAIL_SENDER="DoNotReply@notifications.${STATIC_APP_DOMAIN}"
@@ -165,6 +166,7 @@ VITE_PROJECT_STORAGE_APIM_URL=/api/haste/storage/get-project-artifacts
 VITE_REDIRECT_URI=$STATIC_WEB_APP_URL
 VITE_AZURE_SUBSCRIPTION_ID=$SUBSCRIPTION_ID
 VITE_AZURE_TENANT_ID=$TENANT_ID
+VITE_SHOW_FOOTER=${VITE_SHOW_FOOTER:-false}
 EOF
 
     npm install vite --save-dev
@@ -182,17 +184,153 @@ EOF
 
 }
 
+# Detect the HTTP endpoints currently exposed by a deployed Function App and
+# create a matching APIM operation (plus a set-backend-service policy) for any
+# that don't already exist. Existing operations are left untouched, so this only
+# ever *adds* newly introduced endpoints - making it safe to run on every deploy.
+#
+# The APIM service and the base API (whose api-id matches the function app name)
+# are provisioned by setup/setup_infra.sh. If either is missing we warn and skip
+# rather than fail, so a code-only deploy to an environment without APIM still
+# succeeds.
+sync_apim_operations() {
+    local FUNCTION_NAME=$1
+
+    echo "+--------------------------------------------------+"
+    echo "Syncing APIM operations for function app: $FUNCTION_NAME"
+    echo "+--------------------------------------------------+"
+
+    # The APIM service must exist before we can add operations to it.
+    if ! az apim show --name "$API_MANAGEMENT" --resource-group "$RESOURCE_GROUP" > /dev/null 2>&1; then
+        echo "⚠️  WARNING: API Management service '$API_MANAGEMENT' not found in '$RESOURCE_GROUP'. Skipping APIM operation sync."
+        echo "   Provision APIM and the base API via setup/setup_infra.sh before syncing operations."
+        return 0
+    fi
+
+    # The base API (api-id == function app name) must already be imported into
+    # APIM; new endpoints can only be added to an existing API.
+    if ! az apim api show --resource-group "$RESOURCE_GROUP" --service-name "$API_MANAGEMENT" --api-id "$FUNCTION_NAME" > /dev/null 2>&1; then
+        echo "⚠️  WARNING: APIM API '$FUNCTION_NAME' not found in '$API_MANAGEMENT'. Skipping APIM operation sync."
+        echo "   The base API is created by setup/setup_infra.sh; run it once before relying on incremental endpoint sync."
+        return 0
+    fi
+
+    # Enumerate the function app's endpoints from Azure.
+    local FUNCTION_OPERATIONS
+    FUNCTION_OPERATIONS=$(az functionapp function list --name "$FUNCTION_NAME" --resource-group "$RESOURCE_GROUP" -o json) || {
+        echo "⚠️  WARNING: Failed to list functions for '$FUNCTION_NAME'. Skipping APIM operation sync."
+        return 0
+    }
+
+    while read -r OPERATION; do
+        local OPERATION_NAME OPERATION_METHOD OPERATION_ROUTE TEMPLATE_PARAMETERS
+        OPERATION_NAME=$(echo "$OPERATION" | jq -r '.config.name // (.id | split("/")[-1])')
+        OPERATION_METHOD=$(echo "$OPERATION" | jq -r '.config.bindings[0].methods[0] // empty')
+        OPERATION_ROUTE=$(echo "$OPERATION" | jq -r '.config.bindings[0].route // .config.name')
+
+        # Skip non-HTTP triggers (queue/timer/blob triggers have no HTTP method).
+        if [ -z "$OPERATION_METHOD" ] || [ "$OPERATION_METHOD" = "null" ]; then
+            echo "Skipping '$OPERATION_NAME' (no HTTP method - not an HTTP endpoint)."
+            continue
+        fi
+
+        echo "Processing endpoint: $OPERATION_NAME [method: $OPERATION_METHOD, route: $OPERATION_ROUTE]"
+
+        # Translate route template parameters (e.g. options/{*path}) into the
+        # named template parameter APIM expects.
+        TEMPLATE_PARAMETERS=""
+        case "$OPERATION_ROUTE" in
+            *"{"*"}"*)
+                OPERATION_ROUTE=$(echo "$OPERATION_ROUTE" | sed 's/\*//g')
+                # Extract just the placeholder name from inside the braces so the
+                # declared parameter matches the {param} in the url-template
+                # (e.g. options/{*path} -> url-template options/{path}, param "path").
+                OPERATION_ROUTE_PARAM=$(echo "$OPERATION_ROUTE" | sed -n 's/.*{\([^}]*\)}.*/\1/p')
+                TEMPLATE_PARAMETERS="name=$OPERATION_ROUTE_PARAM required=true type=string"
+                echo "  template parameter detected -> $OPERATION_ROUTE_PARAM"
+                ;;
+        esac
+
+        # Only create operations that don't already exist - this is the "new
+        # endpoint detection" step.
+        if az apim api operation show \
+            --resource-group "$RESOURCE_GROUP" \
+            --service-name "$API_MANAGEMENT" \
+            --api-id "$FUNCTION_NAME" \
+            --operation-id "$OPERATION_NAME" > /dev/null 2>&1; then
+            echo "  operation '$OPERATION_NAME' already exists in APIM. Skipping."
+            continue
+        fi
+
+        echo "  creating new APIM operation '$OPERATION_NAME'..."
+        # shellcheck disable=SC2046
+        az apim api operation create \
+            --resource-group "$RESOURCE_GROUP" \
+            --service-name "$API_MANAGEMENT" \
+            --api-id "$FUNCTION_NAME" \
+            --operation-id "$OPERATION_NAME" \
+            --display-name "$OPERATION_NAME" \
+            --method "$(echo "$OPERATION_METHOD" | tr '[:lower:]' '[:upper:]')" \
+            --url-template "/$OPERATION_ROUTE" \
+            $( [ -n "$TEMPLATE_PARAMETERS" ] && echo "--template-parameters $TEMPLATE_PARAMETERS" ) || {
+            echo "⚠️  WARNING: Failed to create operation '$OPERATION_NAME'. Continuing with remaining endpoints."
+            continue
+        }
+
+        # Route the new operation to the function app backend via policy.
+        local BICEP_TEMPLATE BICEP_TEMPLATE_FILE
+        BICEP_TEMPLATE=$(cat <<EOF
+resource operationPolicy 'Microsoft.ApiManagement/service/apis/operations/policies@2024-06-01-preview' = {
+  name: '$API_MANAGEMENT/$FUNCTION_NAME/$OPERATION_NAME/policy'
+  properties: {
+    value: '''
+<policies>
+  <inbound>
+    <base />
+    <set-backend-service id="apim-generated-policy" backend-id="$FUNCTION_NAME" />
+  </inbound>
+  <backend>
+    <base />
+  </backend>
+  <outbound>
+    <base />
+  </outbound>
+  <on-error>
+    <base />
+  </on-error>
+</policies>
+'''
+    format: 'xml'
+  }
+}
+EOF
+        )
+        BICEP_TEMPLATE_FILE=$(mktemp).bicep
+        echo "$BICEP_TEMPLATE" > "$BICEP_TEMPLATE_FILE"
+        if az deployment group create --resource-group "$RESOURCE_GROUP" --template-file "$BICEP_TEMPLATE_FILE"; then
+            echo "✅ Operation '$OPERATION_NAME' added to APIM and routed to '$FUNCTION_NAME'."
+        else
+            echo "⚠️  WARNING: Failed to set backend policy for '$OPERATION_NAME'."
+        fi
+        rm -f "$BICEP_TEMPLATE_FILE"
+    done < <(echo "$FUNCTION_OPERATIONS" | jq -c '.[]')
+
+    echo "APIM operation sync complete for '$FUNCTION_NAME'."
+}
+
 echo "Deploying component: $COMPONENT"
 
 case "$COMPONENT" in
     all)
         deploy_function "$FUNCTION_API" "$(dirname "$0")/../../api/hastefuncapi" true
+        sync_apim_operations "$FUNCTION_API"
         deploy_function "$FUNCTION_TITILER_API" "$(dirname "$0")/../../api/titilerfuncapi" false
         deploy_function "$FUNCTION_QUEUE_API" "$(dirname "$0")/../../api/hastefuncqueues" true
         deploy_static_web_app
         ;;
     funcapi)
         deploy_function "$FUNCTION_API" "$(dirname "$0")/../../api/hastefuncapi" true
+        sync_apim_operations "$FUNCTION_API"
         ;;
     funcqueue)
         deploy_function "$FUNCTION_QUEUE_API" "$(dirname "$0")/../../api/hastefuncqueues" true

--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -67,6 +67,10 @@ jobs:
       - name: Git LFS Pull
         run: git lfs pull
       - name: Deploy
+        env:
+          # Non-sensitive UI feature flag, baked into the Vite bundle at build time.
+          # Set as a GitHub Environment variable; defaults to false when unset.
+          VITE_SHOW_FOOTER: ${{ vars.VITE_SHOW_FOOTER }}
         run: |
           chmod +x .github/scripts/deploy_apps.sh
           .github/scripts/deploy_apps.sh \


### PR DESCRIPTION
## Description

Bundles the deploy-related fixes targeted for the 1.4.6 release. Supersedes #51 (closed when its branch was renamed).

Three changes:

1. **APIM endpoint sync on deploy.** `.github/scripts/deploy_apps.sh` now detects the HTTP endpoints exposed by the deployed `hastefuncapi` function app (via `az functionapp function list`) and creates a matching APIM operation + `set-backend-service` policy for any that don't already exist. This is idempotent — existing operations are skipped — so newly added `@app.route` handlers stop silently 404/401-ing through APIM because they were never registered. It runs for the `funcapi` and `all` components and is non-fatal when APIM/the base API isn't provisioned (warns and skips), so code-only deploys to environments without APIM still succeed. Also fixes a route-template parameter bug (inherited from `setup_infra.sh`) where the declared APIM parameter name didn't match the `{param}` placeholder in the url-template (e.g. the CORS `options/{*path}` handler).

2. **Configurable app footer.** `VITE_SHOW_FOOTER` is now driven from a GitHub Environment variable (defaults to `false` when unset), baked into the Vite bundle at build time.

3. **Changelog.** Added the 1.4.6 entry covering the above.

Fixes #

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [x] Infrastructure / CI change

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My changes follow the project's coding standards (PEP 8 for Python, ESLint rules for JS/TS)
- [ ] I have added or updated tests that cover my changes
- [ ] All existing tests pass locally (`pytest` / `npm test`)
- [x] I have updated the relevant documentation (README, docs/, inline comments)
- [x] I have added an entry to [CHANGELOG.md](../CHANGELOG.md) if this is a user-facing change

## Testing

- `bash -n .github/scripts/deploy_apps.sh` — syntax validates.
- Verified the route-template transform locally: plain routes (e.g. `GetProjects`) produce no template params; the CORS wildcard `options/{*path}` produces url-template `/options/{path}` with parameter `path` (placeholder and param name now match).
- Live deploy via the `Deploy Azure Applications` workflow (`component: funcapi`) against an environment. snippet from deploy logs:
```
+--------------------------------------------------+
Syncing APIM operations for function app: ***haste***func
+--------------------------------------------------+
Processing endpoint: DeleteLayer [method: DELETE, route: DeleteLayer]
  operation 'DeleteLayer' already exists in APIM. Skipping.
Processing endpoint: DeleteModel [method: DELETE, route: DeleteModel]
  operation 'DeleteModel' already exists in APIM. Skipping.
Processing endpoint: DeleteModelCatalog [method: DELETE, route: DeleteModelCatalog]
  creating new APIM operation 'DeleteModelCatalog'...
ERROR: (ValidationError) One or more fields contain incorrect values:
Code: ValidationError
Message: One or more fields contain incorrect values:
Exception Details:	(ValidationError) Operation with the same method and URL template already exists
	Code: ValidationError
	Message: Operation with the same method and URL template already exists
	Target: urlTemplate	(ValidationError) Operation with the same method and URL template already exists
	Code: ValidationError
	Message: Operation with the same method and URL template already exists
	Target: method
⚠️  WARNING: Failed to create operation 'DeleteModelCatalog'. Continuing with remaining endpoints.
Processing endpoint: DeleteProject [method: DELETE, route: DeleteProject]
  operation 'DeleteProject' already exists in APIM. Skipping.
Processing endpoint: DeleteUser [method: DELETE, route: DeleteUser]
  operation 'DeleteUser' already exists in APIM. Skipping....
...
...
Processing endpoint: UploadFileByChunk [method: POST, route: UploadFileByChunk]
  operation 'UploadFileByChunk' already exists in APIM. Skipping.
APIM operation sync complete for '***haste***func'.
+--------------------------------------------------+
```

## Additional context

The CI script assumes APIM and the base API (api-id == function app name) are already provisioned by `setup/setup_infra.sh`; it only ever adds missing operations, never creates the base API/backend. A follow-up backlog item exists to convert the deploy scripts to Bicep for one-click install.
