### PR TITLE
fix: remove unused GetAdminSettings call that blocks non-admin projec…

### DIFF
--- a/ui/src/Components/CreateEditProjectModalHelper.js
+++ b/ui/src/Components/CreateEditProjectModalHelper.js
@@ -168,7 +168,7 @@ export async function createComponentDefaultState(projectId) {
   if (projectId !== undefined) {
     projectToEdit = await apiGet("GetProjectDetails?projectId=" + projectId);
   }
-  const settings = await apiGet("GetAdminSettings");
+  
   var countries = [];
 
   try {


### PR DESCRIPTION
…t creation

The `createComponentDefaultState` function called `GetAdminSettings` and stored the result in a variable that was never referenced — the function uses `staticSettings` from the local JSON instead. This dead API call returned a 403 for non-administrator users, preventing them from opening the create-project modal.

## Description

<!-- A clear and concise summary of the change and which issue it addresses. -->

Fixes # <!-- issue number, if applicable -->

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Infrastructure / CI change

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My changes follow the project's coding standards (PEP 8 for Python, ESLint rules for JS/TS)
- [ ] I have added or updated tests that cover my changes
- [ ] All existing tests pass locally (`pytest` / `npm test`)
- [ ] I have updated the relevant documentation (README, docs/, inline comments)
- [ ] I have added an entry to [CHANGELOG.md](../CHANGELOG.md) if this is a user-facing change

## Testing

<!-- Describe how you tested these changes. Include relevant commands, screenshots, or logs. -->

## Additional context

<!-- Any other context reviewers should know about. -->
