### PR TITLE
add CHNAGELOG entry for project creation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioning follows the Docker image tags defined in the CI workflows (see [.gith
 
 ---
 
+## [v1.4.7] — Hotfix: non-admin project creation
+
+### Fixed
+- **Non-administrator users couldn't open the Create Project modal** — `createComponentDefaultState` made a `GetAdminSettings` call whose result was never used (the function reads `staticSettings` from local JSON instead). That dead call returned HTTP 403 for non-admin users, blocking the modal from opening. Removed the unused call. ([#53](https://github.com/microsoft/haste/pull/53))
+
+---
+
 ## [v1.4.6] — Building validation & assessment, custom footprints
 
 ### Added


### PR DESCRIPTION
## Description

Cuts **v1.4.7** as a UI hotfix and adds its CHANGELOG section. The underlying code fix already merged in #53: `createComponentDefaultState` made a dead `GetAdminSettings` call whose result was never used (the function reads `staticSettings` from local JSON), and that call returned HTTP 403 for non-administrator users — blocking them from opening the Create Project modal. This PR records the release note so v1.4.7 can be tagged and rolled out to all environments (the swa component) on top of the already-deployed v1.4.6.

Fixes #

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation update
- [ ] Infrastructure / CI change

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My changes follow the project's coding standards (PEP 8 for Python, ESLint rules for JS/TS)
- [ ] I have added or updated tests that cover my changes
- [ ] All existing tests pass locally (`pytest` / `npm test`)
- [x] I have updated the relevant documentation (README, docs/, inline comments)
- [x] I have added an entry to [CHANGELOG.md](../CHANGELOG.md) if this is a user-facing change

## Testing

CHANGELOG-only change — no code modified in this PR. The fix itself was verified in #53.

## Additional context

Hotfix on top of v1.4.6, which is already deployed to several environments. v1.4.7 goes out to all environments via the `deploy-apps` workflow with `component: swa` and `app_tag: 1.4.7`.
