### PR TITLE
fix(deps): upgrade pyarrow 18.1.0 → 23.0.1 (CVE-2026-25087)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioning follows the Docker image tags defined in the CI workflows (see [.gith
 
 ---
 
+## [Unreleased]
+
+### Security
+- **`pyarrow` upgraded 18.1.0 → 23.0.1 (CVE-2026-25087, High)** — Patches a use-after-free in pyarrow's IPC file reader (triggered with pre-buffering enabled) where a crafted Arrow/Parquet file could corrupt memory and potentially execute code inside the **imageryprep** Azure Batch node, exposing its Managed Service Identity token (Blob / Data Lake read+write). Bumped the pin in `docker/imageryprep/requirements.txt` (`pyarrow==23.0.1`) and raised the floor to `pyarrow>=23.0.1` in `hastelib/pyproject.toml`, which also lifts the API containers once a new `hastegeo` wheel is published. ([#57](https://github.com/microsoft/haste/issues/57))
+
+---
+
 ## [v1.4.7] — Hotfix: non-admin project creation
 
 ### Fixed

--- a/docker/imageryprep/requirements.txt
+++ b/docker/imageryprep/requirements.txt
@@ -27,7 +27,7 @@ boto3==1.36.20
 tensorboard==2.19.0
 tenacity==9.1.2
 geopandas==1.1.2
-pyarrow==18.1.0
+pyarrow==23.0.1
 fiona==1.10.1
 fsspec==2024.10.0
 adlfs==2024.12.0

--- a/hastelib/pyproject.toml
+++ b/hastelib/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
   "shapely",
   "fiona",
   "geopandas",
-  "pyarrow",
+  "pyarrow>=23.0.1",
   "fsspec",
   "adlfs",
   "pyyaml",


### PR DESCRIPTION
## What

Upgrade `pyarrow` **18.1.0 → 23.0.1** to remediate **CVE-2026-25087** / [GHSA-rgxp-2hwp-jwgg](https://github.com/advisories/GHSA-rgxp-2hwp-jwgg) (High) — Dependabot alert 40.

A use-after-free in pyarrow's IPC file reader (pre-buffering enabled) lets a crafted Arrow/Parquet file corrupt memory and potentially execute code inside the **imageryprep** Azure Batch node, exposing its Managed Service Identity token (Blob / Data Lake read+write). `18.1.0` falls within the vulnerable range `>= 15.0.0, < 23.0.1`.

## Changes

- `docker/imageryprep/requirements.txt`: `pyarrow==18.1.0` → `pyarrow==23.0.1`
- `hastelib/pyproject.toml`: `"pyarrow"` → `"pyarrow>=23.0.1"` — raises the source floor; this also lifts the API containers (`hastefuncapi`/`hastefuncqueues`, which pull pyarrow transitively via the wheel) once a new `hastegeo` wheel is published.
- `CHANGELOG.md`: Security entry.

The `hastegeo` wheel reference is intentionally **not** touched — it is auto-managed by `hastelib/haste_build.py` on `hatch build`.

## Verification (local)

The pyarrow surface HASTE uses is concentrated in `hastelib/src/hastegeo/core/utils/footprints.py` (the Overture Maps reader). The existing `test_footprints.py` mocks `fsspec`, so it does **not** exercise the IPC reader — an explicit Arrow/Parquet smoke test was added for this change.

- ✅ **imageryprep image builds** with `pyarrow==23.0.1` alongside the full GDAL 3.9.2 / rasterio / geopandas 1.1.2 / adlfs / fsspec / fiona / opencv stack (deps resolve cleanly; numpy 2.4.6, pandas 3.0.3 pulled in).
- ✅ **24 footprints unit tests pass** inside the image on pyarrow 23.0.1.
- ✅ **Arrow/Parquet smoke test passes** — exercises the exact reader APIs: `ds.dataset` → `to_batches(filter=<nested pc.field>)` → `pa.RecordBatchReader.from_batches` → `geoarrow_schema_adapter` → `gpd.GeoDataFrame.from_arrow` (nested-bbox filter returns the expected row with valid geometry).

## Issue checklist (#57)

- [x] Build imageryprep Docker image with `pyarrow==23.0.1`
- [x] Verify Arrow/Parquet read/write operations produce correct output
- [ ] Run imageryprep pipeline smoke tests end-to-end — **ops handoff** (needs Azure Batch infra; not runnable in CI/local)
- [ ] Confirm Azure Batch job completes successfully — **ops handoff**

## Out of scope (follow-up)

`docker/training/env/env.yml` also pins the vulnerable `pyarrow==18.1.0` and runs on Azure Batch, but its heavier ML stack (torchgeo, deltalake, dask_geopandas, planetary_computer) needs separate compatibility verification. Tracked in #60.

> Note: the issue references `docs/security-triage-2026-06-23.md`, which does not exist in the repo.

Refs #57

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
