### PR TITLE
Mgmachado/fix/too much blue on zoom out

### DIFF
--- a/api/hastefuncapi/requirements.txt
+++ b/api/hastefuncapi/requirements.txt
@@ -29,5 +29,5 @@ tenacity==9.1.2
 typing-extensions==4.14.1
 docker==7.1.0
 # Use wheel for remote, comment out for local Docker (source is copied directly)
-hastegeo @ https://researchlabwuopendata.blob.core.windows.net/haste-binaries/hastegeo-1.0.18-py3-none-any.whl
+hastegeo @ https://researchlabwuopendata.blob.core.windows.net/haste-binaries/hastegeo-1.0.19-py3-none-any.whl
 # -e ../../hastelib # for local development only

--- a/api/hastefuncqueues/requirements.txt
+++ b/api/hastefuncqueues/requirements.txt
@@ -29,5 +29,5 @@ tenacity==9.1.2
 typing-extensions==4.14.1
 docker==7.1.0
 # Use wheel for remote, comment out for local Docker (source is copied directly)
-hastegeo @ https://researchlabwuopendata.blob.core.windows.net/haste-binaries/hastegeo-1.0.18-py3-none-any.whl
+hastegeo @ https://researchlabwuopendata.blob.core.windows.net/haste-binaries/hastegeo-1.0.19-py3-none-any.whl
 # -e ../../hastelib # for local development only

--- a/docker/imageryprep/requirements.txt
+++ b/docker/imageryprep/requirements.txt
@@ -31,4 +31,4 @@ pyarrow==18.1.0
 fiona==1.10.1
 fsspec==2024.10.0
 adlfs==2024.12.0
-hastegeo @ https://researchlabwuopendata.blob.core.windows.net/haste-binaries/hastegeo-1.0.18-py3-none-any.whl
+hastegeo @ https://researchlabwuopendata.blob.core.windows.net/haste-binaries/hastegeo-1.0.19-py3-none-any.whl

--- a/hastelib/src/hastegeo/__about__.py
+++ b/hastelib/src/hastegeo/__about__.py
@@ -1,3 +1,3 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-__version__ = "1.0.18"
+__version__ = "1.0.19"

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -381,7 +381,6 @@
       "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.28.1.tgz",
       "integrity": "sha512-OHHEWMB5+Zrix8yKvLVzU3rKDFvh7SOzAzXfICD7YgUXLxfHpTPX2pzOotrri1kskwhHqIj4a5LvhZlIqE7C7g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@azure/msal-common": "14.16.0"
       },
@@ -585,7 +584,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -845,6 +843,31 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
@@ -852,6 +875,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2391,7 +2415,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -2402,7 +2425,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2463,7 +2485,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3018,7 +3039,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3199,7 +3219,6 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
       "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -3781,7 +3800,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4465,7 +4483,6 @@
       "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4702,7 +4719,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9107,7 +9123,6 @@
       "version": "4.0.4",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9675,7 +9690,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10360,6 +10374,7 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -11308,7 +11323,6 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -11853,7 +11867,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/ui/public/staticwebapp.config.json
+++ b/ui/public/staticwebapp.config.json
@@ -1,6 +1,6 @@
 {
   "globalHeaders": {
-    "Content-Security-Policy": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self' https://atlas.microsoft.com; style-src 'self' 'unsafe-inline' https://atlas.microsoft.com; font-src 'self' data: https://atlas.microsoft.com https://c.s-microsoft.com https://*.cdn.office.net; img-src 'self' data: blob: https://atlas.microsoft.com https://*.atlas.microsoft.com https://*.tile.openstreetmap.org; connect-src 'self' https://atlas.microsoft.com https://*.atlas.microsoft.com https://*.tile.openstreetmap.org; worker-src 'self' blob:; child-src blob:",
+    "Content-Security-Policy": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self' https://atlas.microsoft.com; style-src 'self' 'unsafe-inline' https://atlas.microsoft.com; font-src 'self' data: https://atlas.microsoft.com https://c.s-microsoft.com https://*.cdn.office.net; img-src 'self' data: blob: https://atlas.microsoft.com https://*.atlas.microsoft.com https://*.tile.openstreetmap.org; connect-src 'self' https://atlas.microsoft.com https://*.atlas.microsoft.com https://*.tile.openstreetmap.org https://*.blob.core.windows.net; worker-src 'self' blob:; child-src blob:",
     "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
     "X-Content-Type-Options": "nosniff",
     "X-Frame-Options": "DENY",

--- a/ui/src/Components/InteractiveLabeler/InteractiveLabeler.jsx
+++ b/ui/src/Components/InteractiveLabeler/InteractiveLabeler.jsx
@@ -35,7 +35,7 @@ import {
   getAzureMapsAuthOptions,
   isAzureMapsPlaceholder,
 } from "../../util/azureMapsAuth";
-import { toBrowserBlobUrl } from "../../util/blobUrl";
+import { toBrowserBlobUrl, toBrowserTitilerUrl } from "../../util/blobUrl";
 import { AppContext } from "../../AppContext.jsx";
 import { loadImagery } from "../LabelingTool/LabelingToolHelper.js";
 import {
@@ -323,7 +323,7 @@ const InteractiveLabeler = () => {
 
       if (layerData?.imagery?.preEventTileUrl) {
         loadImagery(
-          layerData.imagery.preEventTileUrl,
+          toBrowserTitilerUrl(layerData.imagery.preEventTileUrl),
           map,
           { current: null },
           "preEventImageryLayer",
@@ -332,7 +332,7 @@ const InteractiveLabeler = () => {
       }
       if (layerData?.imagery?.postEventTileUrl) {
         loadImagery(
-          layerData.imagery.postEventTileUrl,
+          toBrowserTitilerUrl(layerData.imagery.postEventTileUrl),
           map,
           { current: null },
           "postEventImageryLayer",

--- a/ui/src/Components/InteractiveLabeler/InteractiveLabeler.jsx
+++ b/ui/src/Components/InteractiveLabeler/InteractiveLabeler.jsx
@@ -21,6 +21,7 @@
 import { useContext, useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import {
+  ActionButton,
   ChoiceGroup,
   DefaultButton,
   PrimaryButton,
@@ -365,7 +366,11 @@ const InteractiveLabeler = () => {
         {
           sourceLayer: PMTILES_SOURCE_LAYER,
           fillColor: fillColorExpr("label"),
-          fillOpacity: 0.5,
+          fillOpacity: [
+            "step", ["zoom"],
+            0.01, // below zoom 15: nearly invisible
+            15, 0.5, // at zoom 15+: normal
+          ],
         }
       );
       map.layers.add(fillLayer);
@@ -375,6 +380,11 @@ const InteractiveLabeler = () => {
           sourceLayer: PMTILES_SOURCE_LAYER,
           strokeColor: "#1a5276",
           strokeWidth: 1,
+          strokeOpacity: [
+            "step", ["zoom"],
+            0.01, // below zoom 15: nearly invisible
+            15, 1, // at zoom 15+: normal
+          ],
         })
       );
 
@@ -1088,23 +1098,25 @@ const InteractiveLabeler = () => {
         overflow: "hidden",
       }}
     >
-      <button
-        onClick={() => navigate(`/project/${projectId}`)}
+      <div
         style={{
           position: "absolute",
-          top: 12,
-          left: 12,
+          left: 10,
+          top: 10,
+          backgroundColor: "rgba(255, 255, 255, 1)",
+          padding: "5px 10px",
+          borderRadius: "5px",
           zIndex: 1000,
-          background: "rgba(255,255,255,0.9)",
-          border: "1px solid #ccc",
-          borderRadius: 4,
-          padding: "6px 14px",
-          cursor: "pointer",
-          fontWeight: 500,
         }}
       >
-        ← Back to Project
-      </button>
+        <ActionButton
+          id="backButton"
+          iconProps={{ iconName: "ChevronLeft" }}
+          onClick={() => navigate(`/project/${projectId}`)}
+        >
+          Back
+        </ActionButton>
+      </div>
 
       <div
         ref={mapContainerRef}

--- a/ui/src/util/blobUrl.js
+++ b/ui/src/util/blobUrl.js
@@ -31,3 +31,23 @@ export function toBrowserBlobUrl(url) {
   parsed.hostname = window.location.hostname;
   return parsed.toString();
 }
+
+// Interactive Labeler imagery tiles are served by titiler. Tile-URL templates
+// are persisted with the deployment-relative `/api/titiler/<path>` prefix,
+// which in the cloud is routed by APIM (and in docker by the nginx api-proxy).
+// Running the UI locally via `swa start` there is no such route, so imagery
+// 404s. When VITE_TITILER_URL is set AND the UI is on localhost, rewrite that
+// prefix to a directly-reachable titiler base. No-op in production (non-local
+// host) and when the env var is unset, so it's safe to ship.
+export function toBrowserTitilerUrl(url) {
+  if (typeof url !== "string" || !url) return url;
+  if (typeof window === "undefined") return url;
+  const localHosts = new Set(["localhost", "127.0.0.1"]);
+  if (!localHosts.has(window.location.hostname)) return url;
+  const base = import.meta.env.VITE_TITILER_URL;
+  if (!base) return url;
+  const marker = "/api/titiler/";
+  const idx = url.indexOf(marker);
+  if (idx === -1) return url;
+  return base.replace(/\/+$/, "") + "/" + url.slice(idx + marker.length);
+}


### PR DESCRIPTION
## Description

Polishes the PMTiles-based Interactive Labeler for the demo and unblocks it
end-to-end — footprint loading, imagery, and label-able feature ids. Branches
off `feat/building-labeling-workflow`.

Changes:
- **Hide footprints on zoom out + Back button restyle** — fill and stroke
  opacity step down to ~0.01 below zoom 15 so the layer doesn't haze blue when
  zoomed out; the plain Back `<button>` becomes a FluentUI `ActionButton` to
  match LabelingTool/Visualizer.
- **CSP fix** — add `https://*.blob.core.windows.net` to `connect-src` in
  `staticwebapp.config.json` so the browser can range-fetch the PMTiles
  footprint archive directly from blob storage. Without it the deployed site
  refuses the connection and no footprints load. (Requires rebuild + redeploy.)
- **Local-dev imagery routing** — `toBrowserTitilerUrl` (in `util/blobUrl.js`)
  rewrites the labeler's persisted `/api/titiler/*` tile URLs to a reachable
  titiler base via `VITE_TITILER_URL`, but only when the UI runs on
  `localhost`. No-op in production (deployed builds keep the APIM-routed path).
- **Bump hastegeo to 1.0.19** — the embedding workflow now bakes MVT feature
  ids (`--use-attribute-for-id=id`); re-publishing the wheel + requirements
  pins gets that into deployed embeds. Click/box-select labeling depends on
  those ids (it drops any feature without one).

Fixes #

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [x] Infrastructure / CI change

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My changes follow the project's coding standards (PEP 8 for Python, ESLint rules for JS/TS)
- [ ] I have added or updated tests that cover my changes
- [ ] All existing tests pass locally (`pytest` / `npm test`)
- [x] I have updated the relevant documentation (README, docs/, inline comments)
- [ ] I have added an entry to [CHANGELOG.md](../CHANGELOG.md) if this is a user-facing change

## Testing

Ran the UI locally (`swa start` → Vite + `func host start`) against the dev
storage account:
- **Footprints:** after adding a blob CORS allow-origin for the local UI origin
  and the CSP `connect-src` entry, the PMTiles range requests return `206` and
  footprints render. Verified hide-on-zoom-out (footprints fade below z15) and
  the restyled Back button.
- **Imagery:** titiler tiles load via the local rewrite (`VITE_TITILER_URL` →
  deployed titiler func); confirmed the titiler endpoint is healthy and
  CORS-allows the local origin.
- **Feature-id labeling:** confirmed existing dev tiles predate the
  `--use-attribute-for-id=id` fix (box-select drops all features). The 1.0.19
  bump addresses this at the source; **full label verification is pending a
  deploy + re-embed of the affected layer.**

## Additional context

- The 1.0.19 bump only takes effect for a layer **after it is re-embedded** —
  feature ids are baked into the tiles at embed time.
- The titiler rewrite is **localhost-only** and a no-op in production; it needs
  a local (git-ignored) `VITE_TITILER_URL` and does not change deployed routing.
- The deployed site also needs a storage CORS allow-origin for its UI origin
  (already present for the dev UI) and a CSP rebuild/redeploy.
- A follow-up infra PR will add the `haste_build` wheel-publish guardrail
  (refuse to overwrite an already-published wheel) — intentionally kept out of
  this PR.