### PR TITLE
fix(labeler): serve PMTiles/sidecar via API proxy, not direct blob

### DIFF
--- a/api/hastefuncapi/function_app.py
+++ b/api/hastefuncapi/function_app.py
@@ -39,7 +39,11 @@ from hastegeo.core.processors.metadata import MetadataProcessor
 from hastegeo.core.processors.stats import StatsPreProcessor
 from hastegeo.core.processors.train import TrainPreprocessor
 from hastegeo.core.processors.uploader import FileUploader
-from hastegeo.core.utils.blob import download_blob_to_tempfile
+from hastegeo.core.utils.blob import (
+    download_blob_to_tempfile,
+    parse_byte_range,
+    read_blob_range,
+)
 from hastegeo.core.utils.data import convert_json_to_geojson, filter_roles
 from hastegeo.core.utils.logs import Logger
 from hastegeo.core.utils.metadata import MetadataUtils
@@ -1135,6 +1139,120 @@ async def GetLayerModelsDetails(req: func.HttpRequest) -> func.HttpResponse:
             stack_info=True,
         )
         return func.HttpResponse("Error loading models.", status_code=500)
+
+
+# Embedding-model artifacts the Interactive Labeler fetches by HTTP byte
+# range, mapped to the Model field that holds each blob URL.
+_MODEL_ARTIFACT_URL_FIELDS = {
+    "pmtiles": "pmtilesUrl",
+    "sidecar": "featuresSidecarUrl",
+    "geojson": "embeddingsGeoJSONUrl",
+}
+_MODEL_ARTIFACT_CONTENT_TYPES = {
+    "pmtiles": "application/octet-stream",
+    "sidecar": "application/octet-stream",
+    "geojson": "application/geo+json",
+}
+
+
+@app.route(
+    route="GetModelArtifact",
+    auth_level=AUTH_LEVEL,
+    methods=["GET"],
+)
+async def GetModelArtifact(req: func.HttpRequest) -> func.HttpResponse:
+    """Stream an embedding model's browser artifact via managed identity.
+
+    The Interactive Labeler reads the PMTiles archive (and its features
+    sidecar) by HTTP byte-range straight from the browser. Handing the
+    client a direct ``*.blob.core.windows.net`` SAS URL only works from
+    IPs on the storage firewall allowlist, so remote/mobile/external
+    labelers get a 403. This route keeps the standard HASTE pattern: the
+    browser fetches same-origin ``/api`` and the function app does the
+    blob I/O server-side over the Azure backbone, honoring ``Range`` so
+    pmtiles.js can do partial reads.
+    """
+    try:
+        project_id = _require_guid_param(req, "projectId")
+        model_id = _require_short_int_id_param(req, "modelId")
+    except ValueError as e:
+        return _bad_request(str(e))
+
+    kind = (req.params.get("kind") or "").lower()
+    url_field = _MODEL_ARTIFACT_URL_FIELDS.get(kind)
+    if url_field is None:
+        return _bad_request(
+            f"kind must be one of {sorted(_MODEL_ARTIFACT_URL_FIELDS)}"
+        )
+
+    try:
+        model = await asyncio.to_thread(
+            MetadataProcessor(
+                data_type=config.get_metadata_types().MODEL.value,
+                partition_key=project_id,
+            ).load,
+            model_id,
+        )
+    except FileNotFoundError:
+        return func.HttpResponse("Model not found.", status_code=404)
+    except Exception as e:
+        logger.error(
+            f"GetModelArtifact model load failed: {e}\n"
+            f"{traceback.format_exc()}"
+        )
+        return func.HttpResponse("Error loading model.", status_code=500)
+
+    blob_url = (model or {}).get(url_field) or ""
+    if not blob_url:
+        return func.HttpResponse(
+            "Artifact not available for this model.", status_code=404
+        )
+
+    try:
+        offset, length, is_range = parse_byte_range(req.headers.get("Range"))
+    except ValueError:
+        # Unsupported/suffix/multi-range -> serve the whole object.
+        offset, length, is_range = 0, None, False
+
+    try:
+        result = await read_blob_range(blob_url, offset, length)
+    except ValueError as e:
+        logger.error(f"GetModelArtifact bad blob url: {e}")
+        return func.HttpResponse("Artifact unavailable.", status_code=500)
+    except Exception as e:
+        logger.error(
+            f"GetModelArtifact read failed: {e}\n{traceback.format_exc()}"
+        )
+        return func.HttpResponse("Error reading artifact.", status_code=502)
+
+    content_type = _MODEL_ARTIFACT_CONTENT_TYPES.get(kind, result.content_type)
+    headers = {
+        "Content-Type": content_type,
+        "Accept-Ranges": "bytes",
+        "Content-Length": str(len(result.data)),
+        "Cache-Control": "private, max-age=3600",
+    }
+    if result.etag:
+        headers["ETag"] = (
+            result.etag if result.etag.startswith('"') else f'"{result.etag}"'
+        )
+
+    if is_range:
+        if offset >= result.total_size:
+            return func.HttpResponse(
+                "Requested range not satisfiable.",
+                status_code=416,
+                headers={"Content-Range": f"bytes */{result.total_size}"},
+            )
+        end = offset + len(result.data) - 1
+        headers["Content-Range"] = f"bytes {offset}-{end}/{result.total_size}"
+        return func.HttpResponse(
+            body=result.data, status_code=206, headers=headers
+        )
+
+    return func.HttpResponse(
+        body=result.data, status_code=200, headers=headers
+    )
 
 
 @app.route(

--- a/api/hastefuncapi/requirements.txt
+++ b/api/hastefuncapi/requirements.txt
@@ -29,5 +29,5 @@ tenacity==9.1.2
 typing-extensions==4.14.1
 docker==7.1.0
 # Use wheel for remote, comment out for local Docker (source is copied directly)
-hastegeo @ https://researchlabwuopendata.blob.core.windows.net/haste-binaries/hastegeo-1.0.22-py3-none-any.whl
+hastegeo @ https://researchlabwuopendata.blob.core.windows.net/haste-binaries/hastegeo-1.0.9999-py3-none-any.whl
 # -e ../../hastelib # for local development only

--- a/api/hastefuncqueues/requirements.txt
+++ b/api/hastefuncqueues/requirements.txt
@@ -29,5 +29,5 @@ tenacity==9.1.2
 typing-extensions==4.14.1
 docker==7.1.0
 # Use wheel for remote, comment out for local Docker (source is copied directly)
-hastegeo @ https://researchlabwuopendata.blob.core.windows.net/haste-binaries/hastegeo-1.0.22-py3-none-any.whl
+hastegeo @ https://researchlabwuopendata.blob.core.windows.net/haste-binaries/hastegeo-1.0.9999-py3-none-any.whl
 # -e ../../hastelib # for local development only

--- a/docker/imageryprep/requirements.txt
+++ b/docker/imageryprep/requirements.txt
@@ -31,4 +31,4 @@ pyarrow==23.0.1
 fiona==1.10.1
 fsspec==2024.10.0
 adlfs==2024.12.0
-hastegeo @ https://researchlabwuopendata.blob.core.windows.net/haste-binaries/hastegeo-1.0.22-py3-none-any.whl
+hastegeo @ https://researchlabwuopendata.blob.core.windows.net/haste-binaries/hastegeo-1.0.9999-py3-none-any.whl

--- a/hastelib/src/hastegeo/__about__.py
+++ b/hastelib/src/hastegeo/__about__.py
@@ -1,3 +1,3 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-__version__ = "1.0.22"
+__version__ = "1.0.9999"

--- a/hastelib/src/hastegeo/core/utils/blob.py
+++ b/hastelib/src/hastegeo/core/utils/blob.py
@@ -21,8 +21,9 @@ from __future__ import annotations
 
 import asyncio
 import os
+import re
 import tempfile
-from typing import Tuple
+from typing import NamedTuple, Optional, Tuple
 from urllib.parse import urlparse
 
 
@@ -85,3 +86,86 @@ async def download_blob_to_tempfile(url: str, suffix: str = "") -> str:
     with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
         tmp.write(blob_bytes)
         return tmp.name
+
+
+class BlobRange(NamedTuple):
+    """A slice of a blob plus the metadata needed to build HTTP headers."""
+
+    data: bytes
+    total_size: int
+    content_type: str
+    etag: Optional[str]
+
+
+def parse_byte_range(
+    value: Optional[str],
+) -> Tuple[int, Optional[int], bool]:
+    """Parse a single HTTP ``Range`` header of the form ``bytes=start-end``.
+
+    Returns ``(offset, length, is_range)``. ``length`` is ``None`` for an
+    open-ended ``bytes=start-`` range (read to EOF); ``is_range`` is
+    ``False`` when no Range header is present.
+
+    Raises:
+        ValueError: for suffix ranges (``bytes=-N``), multi-range values,
+            or otherwise malformed syntax. Callers should fall back to a
+            full ``200`` response in that case.
+    """
+    if not value:
+        return 0, None, False
+    match = re.match(r"^bytes=(\d*)-(\d*)$", value.strip())
+    if not match:
+        raise ValueError(f"Unsupported Range header: {value!r}")
+    start_s, end_s = match.group(1), match.group(2)
+    if start_s == "":
+        # Suffix range (last N bytes) — not emitted by pmtiles.js.
+        raise ValueError(f"Suffix Range unsupported: {value!r}")
+    offset = int(start_s)
+    if end_s == "":
+        return offset, None, True
+    end = int(end_s)
+    if end < offset:
+        raise ValueError(f"Invalid Range bounds: {value!r}")
+    return offset, end - offset + 1, True
+
+
+async def read_blob_range(
+    url: str, offset: int = 0, length: Optional[int] = None
+) -> BlobRange:
+    """Read ``length`` bytes from ``offset`` of the blob at ``url``.
+
+    Routes the read through the function-app-internal
+    ``BLOB_CONNECTION_STRING`` (so it stays on the docker network in dev
+    and on the Azure backbone in prod); only the container/blob path is
+    taken from ``url`` — its host and SAS are ignored. ``length=None``
+    reads to EOF. ``data`` is clamped to the blob size; an ``offset`` at
+    or past EOF yields empty ``data`` (callers should answer ``416``).
+    """
+    from azure.storage.blob import BlobServiceClient
+
+    conn_str = os.environ.get("BLOB_CONNECTION_STRING", "")
+    container_name, blob_name = split_blob_url(url)
+
+    def _read() -> BlobRange:
+        bsc = BlobServiceClient.from_connection_string(conn_str)
+        blob_client = bsc.get_container_client(container_name).get_blob_client(
+            blob_name
+        )
+        props = blob_client.get_blob_properties()
+        total = props.size or 0
+        settings = props.content_settings
+        content_type = (
+            settings.content_type if settings else None
+        ) or "application/octet-stream"
+        if total == 0 or offset >= total:
+            return BlobRange(b"", total, content_type, props.etag)
+        if length is None:
+            downloader = blob_client.download_blob(offset=offset)
+        else:
+            clamped = max(0, min(length, total - offset))
+            downloader = blob_client.download_blob(
+                offset=offset, length=clamped
+            )
+        return BlobRange(downloader.readall(), total, content_type, props.etag)
+
+    return await asyncio.to_thread(_read)

--- a/hastelib/tests/core/utils/test_blob.py
+++ b/hastelib/tests/core/utils/test_blob.py
@@ -10,7 +10,7 @@ existing test_artifacts.py.
 
 import unittest
 
-from hastegeo.core.utils.blob import split_blob_url
+from hastegeo.core.utils.blob import parse_byte_range, split_blob_url
 
 
 class TestSplitBlobUrl(unittest.TestCase):
@@ -59,6 +59,41 @@ class TestSplitBlobUrl(unittest.TestCase):
     def test_azurite_short_url_raises(self):
         with self.assertRaises(ValueError):
             split_blob_url("http://azurite:10000/devstoreaccount1/data")
+
+
+class TestParseByteRange(unittest.TestCase):
+    def test_no_header(self):
+        self.assertEqual(parse_byte_range(None), (0, None, False))
+        self.assertEqual(parse_byte_range(""), (0, None, False))
+
+    def test_closed_range(self):
+        # pmtiles.js' typical header read.
+        self.assertEqual(parse_byte_range("bytes=0-16383"), (0, 16384, True))
+        self.assertEqual(parse_byte_range("bytes=100-199"), (100, 100, True))
+
+    def test_open_ended_range(self):
+        self.assertEqual(parse_byte_range("bytes=200-"), (200, None, True))
+
+    def test_whitespace_tolerated(self):
+        self.assertEqual(parse_byte_range(" bytes=0-9 "), (0, 10, True))
+
+    def test_suffix_range_unsupported(self):
+        with self.assertRaises(ValueError):
+            parse_byte_range("bytes=-500")
+
+    def test_multi_range_unsupported(self):
+        with self.assertRaises(ValueError):
+            parse_byte_range("bytes=0-9,20-29")
+
+    def test_malformed_raises(self):
+        with self.assertRaises(ValueError):
+            parse_byte_range("kilobytes=0-9")
+        with self.assertRaises(ValueError):
+            parse_byte_range("bytes=abc-def")
+
+    def test_inverted_bounds_raise(self):
+        with self.assertRaises(ValueError):
+            parse_byte_range("bytes=200-100")
 
 
 if __name__ == "__main__":

--- a/ui/src/Components/InteractiveLabeler/InteractiveLabeler.jsx
+++ b/ui/src/Components/InteractiveLabeler/InteractiveLabeler.jsx
@@ -30,12 +30,12 @@ import {
   Toggle,
 } from "@fluentui/react";
 import { PMTiles, Protocol } from "pmtiles";
-import { apiGet, apiPut } from "../../util/api";
+import { apiGet, apiPut, buildUrl } from "../../util/api";
 import {
   getAzureMapsAuthOptions,
   isAzureMapsPlaceholder,
 } from "../../util/azureMapsAuth";
-import { toBrowserBlobUrl, toBrowserTitilerUrl } from "../../util/blobUrl";
+import { toBrowserTitilerUrl } from "../../util/blobUrl";
 import { AppContext } from "../../AppContext.jsx";
 import { loadImagery } from "../LabelingTool/LabelingToolHelper.js";
 import {
@@ -325,9 +325,19 @@ const InteractiveLabeler = () => {
         "No features sidecar available for this model — re-embed the layer to produce one."
       );
     }
-    // Dev-only host rewrite (azurite -> localhost). No-op in prod.
-    const browserPmtilesUrl = toBrowserBlobUrl(pmtilesUrl);
-    const browserSidecarUrl = toBrowserBlobUrl(sidecarUrl);
+    // Fetch both artifacts through the same-origin API proxy: the
+    // GetModelArtifact route streams the blob server-side via managed
+    // identity and honors Range for pmtiles.js. This keeps the browser
+    // off the firewalled storage account — a direct *.blob SAS URL only
+    // works from allowlisted IPs, so remote/mobile labelers hit a 403.
+    const browserPmtilesUrl = buildUrl(
+      `GetModelArtifact?projectId=${projectId}&modelId=${modelId}` +
+        `&kind=pmtiles`
+    );
+    const browserSidecarUrl = buildUrl(
+      `GetModelArtifact?projectId=${projectId}&modelId=${modelId}` +
+        `&kind=sidecar`
+    );
 
     // Read the PMTiles header up front so we can place the camera over the
     // archive's bounds (otherwise the map sits at [0, 0] zoom 3 and the user

--- a/ui/src/util/api.js
+++ b/ui/src/util/api.js
@@ -11,7 +11,7 @@ function resolveVarConcatChar(text) {
   return text.includes("?") ? "&" : "?";
 }
 
-function buildUrl(endpoint) {
+export function buildUrl(endpoint) {
   const base = APIUrl + endpoint;
   if (APIMSubscriptionKey) {
     const sep = base.includes("?") ? "&" : "?";


### PR DESCRIPTION
## What

The Interactive Labeler (added in #42) fetches the PMTiles archive and the
features sidecar by HTTP byte-range **directly from the browser**
(`pmtiles.js`). Those requests hit `ai4glhastedev1sa.blob.core.windows.net`
directly, and that account is default-deny with an IP allowlist, so a
labeler on a non-allowlisted network (remote / mobile / external) gets
`403 AuthorizationFailure`. The SAS, the `image-layer-r-policy` stored
access policy, CORS, and the account keys are all healthy — the 403 is the
storage firewall denying the client IP, not a bad token.

## Change

Bring these reads back onto the standard HASTE pattern (imagery already
goes through TiTiler server-side). New `GET /api/GetModelArtifact` streams
the blob **server-side via the internal connection** (managed identity over
the Azure backbone) and **honors HTTP `Range`** so pmtiles.js partial reads
keep working. The labeler now fetches both artifacts through this
same-origin endpoint instead of a direct `*.blob.core.windows.net` SAS URL.

- `hastelib/.../core/utils/blob.py`: `parse_byte_range` + `read_blob_range`
- `api/hastefuncapi/function_app.py`: `GetModelArtifact` (pmtiles / sidecar / geojson)
- `ui/src/util/api.js`: export `buildUrl`
- `ui/.../InteractiveLabeler.jsx`: fetch via the proxy; drop `toBrowserBlobUrl`
- `hastelib/tests/core/utils/test_blob.py`: tests for `parse_byte_range`

No SAS in the browser, no allowlisted IP needed; works for mobile / remote /
external labelers.

## Validation

- flake8 / black / isort clean on touched Python
- 15/15 `test_blob` unit tests pass
- UI `npm run build` succeeds
- Confirmed the blob/policy are fine and the firewall is the gate: the exact
  failing SAS returned the file when requested from an IP I temporarily
  allowlisted, and was network-blocked from the same host before.

## Ops follow-up

The new endpoint needs an **APIM operation** in dev/prod that forwards the
`Range` request header and passes `206` / `Content-Range` responses through
(no buffering). The docker nginx api-proxy and `swa start` forward Range by
default.

## Root-cause confidence

Strong but not 100% end-to-end: I confirmed a valid SAS works from an
allowlisted IP and is network-blocked otherwise, but haven't yet diffed a
failing user's egress IP against the allowlist. The proxy fixes the symptom
regardless of that last-mile confirmation.

Targets `feat/building-labeling-workflow` since the labeler isn't merged to
`main` yet.
