### PR TITLE
chore(build): host GDAL and hastegeo wheels on GitHub Releases

### DIFF
--- a/.github/rc-retain.txt
+++ b/.github/rc-retain.txt
@@ -1,0 +1,4 @@
+# hastegeo rc wheels to retain (never auto-pruned by rc-cleanup.yml).
+# One asset filename per line, e.g.:
+#   hastegeo-1.5.0rc7-py3-none-any.whl
+# Lines starting with # are ignored.

--- a/.github/scripts/cleanup_rc_releases.py
+++ b/.github/scripts/cleanup_rc_releases.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+"""Prune old hastegeo release-candidate wheels from the haste-binaries release.
+
+For each target version, once its stable wheel is published every rc for that
+version is obsolete and removed; otherwise the most recent ``--keep`` rc wheels
+are retained. Asset names listed in ``--retain-file`` are never deleted.
+Dry-run by default; pass ``--apply`` to actually delete.
+"""
+
+import argparse
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Sequence
+
+REPO = "microsoft/haste"
+RELEASE_TAG = "haste-binaries"
+STABLE_RE = re.compile(r"^hastegeo-(\d+)\.(\d+)\.(\d+)-py3-none-any\.whl$")
+RC_RE = re.compile(r"^hastegeo-(\d+)\.(\d+)\.(\d+)rc(\d+)-py3-none-any\.whl$")
+
+
+def _gh(args: Sequence[str]) -> str:
+    """Run a gh command scoped to the HASTE repo and return stdout."""
+    return subprocess.run(
+        ["gh", *args, "--repo", REPO],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+
+def list_assets() -> list[dict[str, object]]:
+    """Return [{name, apiUrl}, ...] for the release's assets."""
+    out = _gh(
+        [
+            "release",
+            "view",
+            RELEASE_TAG,
+            "--json",
+            "assets",
+            "--jq",
+            ".assets[] | {name: .name, apiUrl: .apiUrl}",
+        ]
+    )
+    return [json.loads(line) for line in out.splitlines() if line.strip()]
+
+
+def plan_deletions(
+    assets: Sequence[dict[str, object]],
+    keep: int,
+    retain: set[str],
+) -> list[dict[str, object]]:
+    """Return the list of rc assets that should be deleted."""
+    if keep < 0:
+        raise ValueError("keep must be non-negative")
+
+    stable = set()
+    rcs: dict[tuple[int, int, int], list[tuple[int, dict[str, object]]]] = {}
+    for asset in assets:
+        name = str(asset["name"])
+        stable_match = STABLE_RE.match(name)
+        if stable_match:
+            stable.add(tuple(int(x) for x in stable_match.groups()))
+            continue
+        rc_match = RC_RE.match(name)
+        if rc_match:
+            target = tuple(int(x) for x in rc_match.groups()[:3])
+            rcs.setdefault(target, []).append((int(rc_match.group(4)), asset))
+
+    to_delete = []
+    for target, items in rcs.items():
+        items.sort(key=lambda pair: pair[0])
+        if target in stable:
+            doomed = items  # superseded by the stable release
+        else:
+            doomed = items[:-keep] if keep > 0 else items
+        for _, asset in doomed:
+            if str(asset["name"]) not in retain:
+                to_delete.append(asset)
+    return to_delete
+
+
+def _delete_asset(api_url: str) -> None:
+    subprocess.run(
+        ["gh", "api", "-X", "DELETE", api_url],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _load_retain(path: str | None) -> set[str]:
+    if not path:
+        return set()
+    retain_path = Path(path)
+    if not retain_path.is_file():
+        raise FileNotFoundError(
+            f"Configured retain file does not exist: {retain_path}"
+        )
+    with retain_path.open(encoding="utf-8") as handle:
+        return {
+            line.strip()
+            for line in handle
+            if line.strip() and not line.startswith("#")
+        }
+
+
+def _non_negative_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be non-negative")
+    return parsed
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--keep",
+        type=_non_negative_int,
+        default=5,
+        help="rc wheels to keep per unreleased version (default: 5)",
+    )
+    parser.add_argument(
+        "--retain-file", help="file of asset names to never delete"
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="delete for real (default: dry-run)",
+    )
+    args = parser.parse_args(argv)
+
+    retain = _load_retain(args.retain_file)
+    to_delete = plan_deletions(list_assets(), args.keep, retain)
+
+    if not to_delete:
+        print("No rc wheels to prune.")
+        return 0
+
+    for asset in to_delete:
+        if args.apply:
+            _delete_asset(str(asset["apiUrl"]))
+            print(f"deleted {asset['name']}")
+        else:
+            print(f"[dry-run] would delete {asset['name']}")
+    verb = "Deleted" if args.apply else "Would delete"
+    print(f"{verb} {len(to_delete)} rc wheel(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/deploy_apps.sh
+++ b/.github/scripts/deploy_apps.sh
@@ -119,15 +119,26 @@ deploy_function() {
 
     az functionapp restart --name "$FUNCTION_NAME" --resource-group "$RESOURCE_GROUP"
 
-    echo "Deploying function code..."
-    # Deploy and handle health check failures gracefully
-    if (cd "$FUNCTION_DIR" && func azure functionapp publish "$FUNCTION_NAME" --python --build remote --verbose); then
-        echo "✅ Function deployment completed successfully"
-    else
-        echo "⚠️  WARNING: Function deployment completed but health check failed."
-        echo "   This is often normal for cold starts and doesn't indicate a real problem."
-        echo "   The function app is likely working correctly. Check the Azure portal to verify."
+    # Function apps publish via `func` -> remote pip install on Azure, so the
+    # editable hastegeo default in requirements.txt (used by docker-compose)
+    # must be swapped for the published wheel. Apps without a hastegeo line
+    # (e.g. titiler) are left untouched.
+    if [ -n "${HASTEGEO_WHEEL_URL:-}" ] && grep -qE '^[[:space:]]*#?[[:space:]]*(-e[[:space:]]+[^[:space:]]*hastelib|hastegeo[[:space:]]*@)' "$FUNCTION_DIR/requirements.txt" 2>/dev/null; then
+        echo "Pinning hastegeo wheel for $FUNCTION_NAME: $HASTEGEO_WHEEL_URL"
+        python3 "$(dirname "$0")/set_hastegeo_source.py" --mode wheel --url "$HASTEGEO_WHEEL_URL" "$FUNCTION_DIR/requirements.txt"
     fi
+
+    echo "Deploying function code..."
+    # A non-zero exit can represent a package/build/deployment failure. Do not
+    # convert it into a success-shaped warning: set -e propagates the failure.
+    (
+        cd "$FUNCTION_DIR"
+        func azure functionapp publish "$FUNCTION_NAME" \
+            --python \
+            --build remote \
+            --verbose
+    )
+    echo "Function deployment completed successfully."
 
     echo "Setting tags for Function App $FUNCTION_NAME ..."
     az functionapp update --name "$FUNCTION_NAME" --resource-group "$RESOURCE_GROUP" --set $AZ_FUNCTIONAPP_TAGS

--- a/.github/scripts/publish_hastegeo_wheel.py
+++ b/.github/scripts/publish_hastegeo_wheel.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+"""Validate and publish one immutable hastegeo wheel release asset."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import zipfile
+from dataclasses import dataclass
+from email.parser import BytesParser
+from pathlib import Path
+from typing import Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "hastelib"))
+
+from haste_release import (  # noqa: E402
+    RC_VERSION_RE,
+    RELEASE_TAG,
+    REPOSITORY,
+    STABLE_VERSION_RE,
+    list_release_assets,
+)
+
+
+@dataclass(frozen=True)
+class WheelIdentity:
+    """Validated identity of a wheel artifact."""
+
+    path: Path
+    version: str
+    filename: str
+    sha256: str
+
+
+def run_command(command: Sequence[str]) -> str:
+    """Run a command and return stdout, failing on any error."""
+    result = subprocess.run(
+        list(command),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def sha256_file(path: Path) -> str:
+    """Return the SHA256 digest for ``path``."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def validate_wheel(
+    wheel_path: Path, expected_version: str, channel: str
+) -> WheelIdentity:
+    """Validate filename, channel policy, ZIP structure, and METADATA."""
+    if channel == "rc":
+        if not RC_VERSION_RE.fullmatch(expected_version):
+            raise ValueError(
+                f"PR publication requires an rcN version, got "
+                f"{expected_version!r}"
+            )
+    elif channel == "release":
+        if not STABLE_VERSION_RE.fullmatch(expected_version):
+            raise ValueError(
+                f"Main publication requires a stable version, got "
+                f"{expected_version!r}"
+            )
+    else:
+        raise ValueError(f"Unsupported channel: {channel!r}")
+
+    expected_name = f"hastegeo-{expected_version}-py3-none-any.whl"
+    if wheel_path.name != expected_name:
+        raise ValueError(
+            f"Wheel filename {wheel_path.name!r} does not match "
+            f"{expected_name!r}"
+        )
+    if not wheel_path.is_file() or not zipfile.is_zipfile(wheel_path):
+        raise ValueError(f"Not a valid wheel ZIP file: {wheel_path}")
+
+    with zipfile.ZipFile(wheel_path) as archive:
+        metadata_names = [
+            name
+            for name in archive.namelist()
+            if name.endswith(".dist-info/METADATA")
+        ]
+        if len(metadata_names) != 1:
+            raise ValueError(
+                "Wheel must contain exactly one dist-info/METADATA file"
+            )
+        metadata = BytesParser().parsebytes(archive.read(metadata_names[0]))
+
+    if metadata.get("Name", "").lower() != "hastegeo":
+        raise ValueError(
+            f"Wheel project is {metadata.get('Name')!r}, not 'hastegeo'"
+        )
+    if metadata.get("Version") != expected_version:
+        raise ValueError(
+            f"Wheel METADATA version {metadata.get('Version')!r} does not "
+            f"match {expected_version!r}"
+        )
+
+    return WheelIdentity(
+        path=wheel_path,
+        version=expected_version,
+        filename=expected_name,
+        sha256=sha256_file(wheel_path),
+    )
+
+
+def get_tag_sha(tag: str) -> str:
+    """Return the commit SHA for a lightweight release tag, or empty."""
+    result = subprocess.run(
+        [
+            "gh",
+            "api",
+            f"repos/{REPOSITORY}/git/ref/tags/{tag}",
+            "--jq",
+            ".object.sha",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        return result.stdout.strip()
+    if "HTTP 404" in result.stderr:
+        return ""
+    raise RuntimeError(
+        f"Failed to query source tag {tag}: {result.stderr.strip()}"
+    )
+
+
+def ensure_stable_tag(tag: str, source_sha: str) -> None:
+    """Create the stable source tag or verify its existing target."""
+    existing_sha = get_tag_sha(tag)
+    if existing_sha:
+        if existing_sha != source_sha:
+            raise ValueError(
+                f"{tag} points to {existing_sha}, expected {source_sha}"
+            )
+        return
+
+    run_command(
+        [
+            "gh",
+            "api",
+            "-X",
+            "POST",
+            f"repos/{REPOSITORY}/git/refs",
+            "-f",
+            f"ref=refs/tags/{tag}",
+            "-f",
+            f"sha={source_sha}",
+        ]
+    )
+    print(f"Created source tag {tag} at {source_sha}")
+
+
+def publish(
+    identity: WheelIdentity,
+    *,
+    channel: str,
+    source_sha: str,
+) -> str:
+    """Publish ``identity`` without overwriting an existing release asset."""
+    assets = list_release_assets()
+    source_tag = (
+        f"hastegeo-v{identity.version}" if channel == "release" else ""
+    )
+    if channel == "rc":
+        rc_match = RC_VERSION_RE.fullmatch(identity.version)
+        if not rc_match:
+            raise ValueError(f"Invalid RC version: {identity.version}")
+        stable_version = ".".join(rc_match.groups()[:3])
+        stable_name = f"hastegeo-{stable_version}-py3-none-any.whl"
+        if stable_name in assets:
+            raise ValueError(
+                f"Cannot publish {identity.version}: stable asset already "
+                f"exists for {stable_version}"
+            )
+
+    if identity.filename in assets:
+        if channel == "release" and get_tag_sha(source_tag) == source_sha:
+            print(
+                f"{identity.filename} is already published for "
+                f"{source_sha}; no-op."
+            )
+            return (
+                f"https://github.com/{REPOSITORY}/releases/download/"
+                f"{RELEASE_TAG}/{identity.filename}"
+            )
+        raise ValueError(
+            f"Release asset already exists and will not be overwritten: "
+            f"{identity.filename}"
+        )
+
+    if source_tag:
+        # Create the tag before upload. If upload fails, a rerun resolves the
+        # same version from the tag and completes the missing asset.
+        ensure_stable_tag(source_tag, source_sha)
+
+    run_command(
+        [
+            "gh",
+            "release",
+            "upload",
+            RELEASE_TAG,
+            str(identity.path),
+            "--repo",
+            REPOSITORY,
+        ]
+    )
+
+    if identity.filename not in list_release_assets():
+        raise RuntimeError(
+            f"Upload returned success but asset is missing: "
+            f"{identity.filename}"
+        )
+
+    return (
+        f"https://github.com/{REPOSITORY}/releases/download/"
+        f"{RELEASE_TAG}/{identity.filename}"
+    )
+
+
+def emit_outputs(identity: WheelIdentity, url: str = "") -> None:
+    """Emit validation/publication metadata for later workflow jobs."""
+    values = {
+        "published_version": identity.version,
+        "published_url": url,
+        "wheel_name": identity.filename,
+        "wheel_sha256": identity.sha256,
+    }
+    for key, value in values.items():
+        print(f"{key}={value}")
+
+    output_path = (
+        Path(os.environ["GITHUB_OUTPUT"])
+        if "GITHUB_OUTPUT" in os.environ
+        else None
+    )
+    if output_path:
+        with output_path.open("a", encoding="utf-8") as handle:
+            for key, value in values.items():
+                handle.write(f"{key}={value}\n")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--wheel", type=Path, required=True)
+    parser.add_argument("--expected-version", required=True)
+    parser.add_argument("--channel", choices=["rc", "release"], required=True)
+    parser.add_argument("--source-sha", required=True)
+    parser.add_argument(
+        "--validate-only",
+        action="store_true",
+        help="validate the wheel without querying or mutating GitHub",
+    )
+    parser.add_argument("--json-output")
+    args = parser.parse_args(argv)
+
+    identity = validate_wheel(args.wheel, args.expected_version, args.channel)
+    url = ""
+    if not args.validate_only:
+        url = publish(
+            identity,
+            channel=args.channel,
+            source_sha=args.source_sha,
+        )
+    emit_outputs(identity, url)
+
+    if args.json_output:
+        Path(args.json_output).write_text(
+            json.dumps(
+                {
+                    "version": identity.version,
+                    "wheel_name": identity.filename,
+                    "sha256": identity.sha256,
+                    "url": url,
+                    "source_sha": args.source_sha,
+                    "channel": args.channel,
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/resolve_hastegeo_deploy.py
+++ b/.github/scripts/resolve_hastegeo_deploy.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+"""Resolve and verify the exact hastegeo wheel used for deployment."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "hastelib"))
+
+from haste_release import (  # noqa: E402
+    RELEASE_TAG,
+    REPOSITORY,
+    latest_stable,
+    list_release_assets,
+)
+
+DEPLOY_VERSION_RE = re.compile(
+    r"^(\d+)\.(\d+)\.(\d+)(?:\.?rc0*(\d+))?$",
+    re.IGNORECASE,
+)
+
+
+def canonicalize_version(value: str) -> str:
+    """Canonicalize stable or RC input, including ``rc01`` -> ``rc1``."""
+    match = DEPLOY_VERSION_RE.fullmatch(value.strip())
+    if not match:
+        raise ValueError(
+            f"Invalid hastegeo version {value!r}; expected X.Y.Z or X.Y.ZrcN"
+        )
+    major, minor, patch = (int(part) for part in match.groups()[:3])
+    rc = match.group(4)
+    base = f"{major}.{minor}.{patch}"
+    return f"{base}rc{int(rc)}" if rc is not None else base
+
+
+def resolve_deploy_wheel(
+    requested_version: str, assets: Sequence[str]
+) -> tuple[str, str, str]:
+    """Return canonical version, wheel filename, and public URL."""
+    if requested_version.strip():
+        version = canonicalize_version(requested_version)
+    else:
+        version = ".".join(str(part) for part in latest_stable(assets))
+
+    wheel_name = f"hastegeo-{version}-py3-none-any.whl"
+    if wheel_name not in assets:
+        raise ValueError(
+            f"hastegeo release asset does not exist: {wheel_name}"
+        )
+    url = (
+        f"https://github.com/{REPOSITORY}/releases/download/"
+        f"{RELEASE_TAG}/{wheel_name}"
+    )
+    return version, wheel_name, url
+
+
+def emit_outputs(version: str, wheel_name: str, url: str) -> None:
+    values = {
+        "version": version,
+        "wheel_name": wheel_name,
+        "url": url,
+    }
+    for key, value in values.items():
+        print(f"{key}={value}")
+
+    output_path = os.getenv("GITHUB_OUTPUT")
+    if output_path:
+        with open(output_path, "a", encoding="utf-8") as handle:
+            for key, value in values.items():
+                handle.write(f"{key}={value}\n")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", default="")
+    args = parser.parse_args(argv)
+
+    version, wheel_name, url = resolve_deploy_wheel(
+        args.version, list_release_assets()
+    )
+    emit_outputs(version, wheel_name, url)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/resolve_hastegeo_version.py
+++ b/.github/scripts/resolve_hastegeo_version.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+"""Resolve the exact hastegeo RC or stable version for a CI build."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from typing import Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "hastelib"))
+
+from haste_release import (  # noqa: E402
+    Resolution,
+    list_release_assets,
+    resolve,
+    tags_pointing_at,
+)
+
+
+def emit_outputs(resolution: Resolution) -> None:
+    """Write GitHub Actions outputs when GITHUB_OUTPUT is available."""
+    values = {
+        "version": resolution.version,
+        "wheel_name": resolution.wheel_name,
+        "channel": resolution.channel,
+        "source_sha": resolution.source_sha,
+        "source_tag": resolution.source_tag,
+        "already_published": str(resolution.already_published).lower(),
+    }
+    for key, value in values.items():
+        print(f"{key}={value}")
+
+    output_path = os.getenv("GITHUB_OUTPUT")
+    if output_path:
+        with open(output_path, "a", encoding="utf-8") as handle:
+            for key, value in values.items():
+                handle.write(f"{key}={value}\n")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--channel", choices=["rc", "release"], required=True)
+    parser.add_argument("--source-sha", required=True)
+    parser.add_argument(
+        "--bump",
+        choices=["patch", "minor", "major"],
+        default="patch",
+    )
+    parser.add_argument("--set-version", default="")
+    parser.add_argument("--json-output")
+    args = parser.parse_args(argv)
+
+    assets = list_release_assets()
+    tags = (
+        tags_pointing_at(args.source_sha) if args.channel == "release" else []
+    )
+    resolution = resolve(
+        channel=args.channel,
+        source_sha=args.source_sha,
+        assets=assets,
+        tags=tags,
+        bump=args.bump,
+        set_version=args.set_version,
+    )
+    emit_outputs(resolution)
+
+    if args.json_output:
+        Path(args.json_output).write_text(
+            json.dumps(asdict(resolution), indent=2) + "\n",
+            encoding="utf-8",
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/set_hastegeo_source.py
+++ b/.github/scripts/set_hastegeo_source.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+"""Toggle the hastegeo install source in requirements.txt files.
+
+The committed default for the function-app requirements is the editable local
+tree (``-e ../../hastelib``) so ``docker compose`` builds from source with no
+wheel publish. Deployment CI calls this to flip that line to the published
+wheel (``hastegeo @ <url>``) before ``func azure functionapp publish``. The
+inactive alternative is preserved as a comment, so the switch is reversible
+and idempotent.
+
+Usage:
+    set_hastegeo_source.py --mode wheel --url <URL> FILE [FILE ...]
+    set_hastegeo_source.py --mode editable [--path ../../hastelib] FILE ...
+"""
+
+import argparse
+import re
+from pathlib import Path
+from typing import Sequence
+
+EDITABLE_RE = re.compile(r"^\s*#?\s*-e\s+(?P<path>\S*hastelib\S*)\s*$")
+WHEEL_RE = re.compile(r"^\s*#?\s*hastegeo\s*@\s*(?P<url>\S+)\s*$")
+
+
+def rewrite(
+    path: str,
+    mode: str,
+    url: str | None,
+    editable_path: str,
+) -> None:
+    """Rewrite ``path`` with exactly one active hastegeo source line."""
+    requirement_path = Path(path)
+    lines = requirement_path.read_text(encoding="utf-8").splitlines()
+
+    existing_url = None
+    for line in lines:
+        wheel_match = WHEEL_RE.match(line)
+        if wheel_match:
+            existing_url = existing_url or wheel_match.group("url")
+
+    wheel_url = url or existing_url
+    if mode == "wheel" and not wheel_url:
+        raise SystemExit(f"{path}: --url required (no existing wheel line)")
+
+    editable_line = f"-e {editable_path}"
+    wheel_line = f"hastegeo @ {wheel_url}" if wheel_url else None
+
+    first_source_index = next(
+        (
+            index
+            for index, line in enumerate(lines)
+            if EDITABLE_RE.match(line) or WHEEL_RE.match(line)
+        ),
+        len(lines),
+    )
+    out = [
+        line
+        for line in lines
+        if not EDITABLE_RE.match(line) and not WHEEL_RE.match(line)
+    ]
+    source_block = []
+    if mode == "editable":
+        source_block.append(editable_line)
+        if wheel_line:
+            source_block.append(f"# {wheel_line}")
+        active = editable_line
+    else:
+        source_block.extend([f"# {editable_line}", wheel_line])
+        active = wheel_line
+
+    out[first_source_index:first_source_index] = source_block
+    requirement_path.write_text("\n".join(out) + "\n", encoding="utf-8")
+    print(f"{path}: hastegeo source -> {active}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Toggle the hastegeo install source in requirements files."
+    )
+    parser.add_argument("--mode", required=True, choices=["wheel", "editable"])
+    parser.add_argument("--url", help="wheel URL (for --mode wheel)")
+    parser.add_argument(
+        "--path",
+        default="../../hastelib",
+        help="editable path for --mode editable (default: ../../hastelib)",
+    )
+    parser.add_argument("files", nargs="+")
+    args = parser.parse_args(argv)
+    for path in args.files:
+        rewrite(path, args.mode, args.url, args.path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,6 +2,31 @@
 
 This directory contains GitHub Actions workflows for the HASTE project, focused on building and pushing Docker images to Azure Container Registry (ACR) using OpenID Connect (OIDC) authentication and semantic versioning.
 
+## hastegeo Wheel and Versioned Images
+
+`hastegeo-build.yml` handles changes under `hastelib/`:
+
+1. A trusted read-only resolver chooses the next RC or stable version.
+2. An untrusted-source build job runs without write credentials and uploads the
+   validated wheel as an Actions artifact.
+3. `hastegeo-publish.yml`, loaded from `main` through `workflow_run`, validates
+   the artifact again and automatically publishes same-repository PR RCs.
+4. ACR Tasks builds `hastetraining` and `hasteimageryprep` once, in parallel,
+   with the exact same tag as the wheel (`X.Y.ZrcN`).
+5. The workflow comments the matching `hastegeo_version`,
+   `training_image_tag`, and `imageprep_image_tag` on the PR.
+
+Stable releases create `hastegeo-vX.Y.Z` tags, making reruns of the same source
+commit a no-op. Stable publication additionally requires repository variables
+`HASTEGEO_PUBLISH_ENABLED=true` and
+`HASTEGEO_RELEASE_APPROVAL_CONFIGURED=true`.
+
+RC publication is automatic unless `HASTEGEO_RC_PUBLISH_ENABLED=false`.
+Fork PRs remain build-only. The RC image environment is selected through
+`HASTEGEO_RC_ENVIRONMENT`, keeping environment names out of the workflow.
+Before enabling stable publication, repository administrators must configure a
+protected release environment with required reviewers and self-review disabled.
+
 ## Docker Build and Push Workflow
 
 ### Overview
@@ -27,10 +52,11 @@ on:
       - main
 ```
 
-**When**: Automatically triggered when PRs are opened, updated, or synchronized against the `main` branch.
+**When**: Automatically triggered for Docker-only changes. If `hastelib/`
+changes, `hastegeo-build.yml` owns the coherent wheel and image build instead.
 
 **Default Behavior**:
-- **Image Directory**: `all` (builds both images)
+- **Image Directory**: only the changed Docker image
 - **Tag**: `{TAG_PREFIX}-rc{PR_NUMBER}` (e.g., `1.0.1-rc123`)
 
 #### 2. Manual Workflow Dispatch
@@ -332,4 +358,8 @@ These workflows run automatically and require no manual configuration beyond the
 | **Deploy Documentation** | `docs-deploy.yml` | Push to `main`, plus manual dispatch | Builds the Jupyter Book docs and deploys them to GitHub Pages |
 | **Secret Scan** | `secret-scan.yml` | Push and PR to `main`, plus manual dispatch | Runs Gitleaks to detect accidentally committed secrets |
 
-> **Note on the Docker build workflow:** the `detect-changes` job uses [`dorny/paths-filter`](https://github.com/dorny/paths-filter) so that a PR only rebuilds the images whose source actually changed (`docker/training/**` or `hastelib/**` for training, `docker/imageryprep/**` for imagery prep). Manual dispatch always builds the requested image(s).
+> **Note on the Docker build workflow:** the `detect-changes` job uses
+> [`dorny/paths-filter`](https://github.com/dorny/paths-filter) for Docker-only
+> changes. `hastelib/**` changes are intentionally excluded because
+> `hastegeo-publish.yml` builds both final ACR images once with the matching RC
+> wheel tag. Manual dispatch always builds the requested image(s).

--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -19,16 +19,23 @@ on:
           - titiler
           - swa
       training_image_tag:
-        description: "Training Docker image tag"
-        required: true
+        description: "Training image tag (blank = resolved hastegeo version)"
+        required: false
+        default: ""
         type: string
       imageprep_image_tag:
-        description: "Image prep Docker image tag"
-        required: true
+        description: "Imageryprep image tag (blank = resolved hastegeo version)"
+        required: false
+        default: ""
         type: string
       app_tag:
         description: "Application version tag"
         required: true
+        type: string
+      hastegeo_version:
+        description: "hastegeo wheel version to deploy (blank = latest stable release)"
+        required: false
+        default: ""
         type: string
 
 jobs:
@@ -40,10 +47,12 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "24"
       - name: Install tools
@@ -55,10 +64,41 @@ jobs:
           sudo apt-get install git-lfs -y
           git lfs env
           sudo apt-get install azure-functions-core-tools-4 jq git-lfs -y
-          npm install -g @azure/static-web-apps-cli
+          npm install -g @azure/static-web-apps-cli@2.0.9
+
+      - name: Resolve hastegeo wheel URL
+        id: hastegeo
+        if: >-
+          inputs.component == 'all' ||
+          inputs.component == 'funcapi' ||
+          inputs.component == 'funcqueue'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python .github/scripts/resolve_hastegeo_deploy.py \
+            --version "${{ inputs.hastegeo_version }}"
+
+      - name: Resolve matching image tags
+        id: artifacts
+        env:
+          VERSION: ${{ steps.hastegeo.outputs.version }}
+          TRAINING_INPUT: ${{ inputs.training_image_tag }}
+          IMAGEPREP_INPUT: ${{ inputs.imageprep_image_tag }}
+        run: |
+          TRAINING_TAG="${TRAINING_INPUT:-$VERSION}"
+          IMAGEPREP_TAG="${IMAGEPREP_INPUT:-$VERSION}"
+          if [[ "$VERSION" == *rc* ]]; then
+            if [[ "$TRAINING_TAG" != "$VERSION" || \
+                  "$IMAGEPREP_TAG" != "$VERSION" ]]; then
+              echo "::error::RC deployments require matching wheel and image tags"
+              exit 1
+            fi
+          fi
+          echo "training_tag=$TRAINING_TAG" >> "$GITHUB_OUTPUT"
+          echo "imageprep_tag=$IMAGEPREP_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Azure Login
-        uses: azure/login@v2
+        uses: azure/login@1384c340ab2dda50fed2bee3041d1d87018aa5e8 # v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -71,6 +111,10 @@ jobs:
           # Non-sensitive UI feature flag, baked into the Vite bundle at build time.
           # Set as a GitHub Environment variable; defaults to false when unset.
           VITE_SHOW_FOOTER: ${{ vars.VITE_SHOW_FOOTER }}
+          # hastegeo wheel pinned into the function-app requirements before
+          # `func publish` (deploy_apps.sh); the editable default can't resolve
+          # on Azure's remote build.
+          HASTEGEO_WHEEL_URL: ${{ steps.hastegeo.outputs.url }}
         run: |
           chmod +x .github/scripts/deploy_apps.sh
           .github/scripts/deploy_apps.sh \
@@ -80,8 +124,8 @@ jobs:
             "${{ secrets.LOCATION }}" \
             "${{ secrets.RESOURCE_SUFFIX }}" \
             "${{ secrets.ACR_NAME }}" \
-            "${{ inputs.training_image_tag }}" \
-            "${{ inputs.imageprep_image_tag }}" \
+            "${{ steps.artifacts.outputs.training_tag }}" \
+            "${{ steps.artifacts.outputs.imageprep_tag }}" \
             "${{ secrets.ENVIRONMENT_TYPE }}" \
             "${{ inputs.app_tag }}" \
             "${{ secrets.BATCH_ACCOUNT }}" \

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -32,19 +32,23 @@ jobs:
     outputs:
       training: ${{ steps.filter.outputs.training }}
       imageryprep: ${{ steps.filter.outputs.imageryprep }}
+      hastelib: ${{ steps.filter.outputs.hastelib }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v3
         id: filter
-        # On manual dispatch always build the requested image(s)
+        # Hastegeo changes are handled by hastegeo-publish.yml so images use
+        # the exact matching RC tag and are not built twice.
         if: github.event_name == 'pull_request'
         with:
           filters: |
             training:
               - 'docker/training/**'
-              - 'hastelib/**'
             imageryprep:
               - 'docker/imageryprep/**'
+            hastelib:
               - 'hastelib/**'
 
   build-and-push:
@@ -63,7 +67,9 @@ jobs:
             changed: ${{ needs.detect-changes.outputs.imageryprep }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Resolve image selection
         id: resolve
@@ -72,23 +78,21 @@ jobs:
           INPUT="${{ github.event.inputs.image_dir || 'all' }}"
           MATRIX_IMAGE="${{ matrix.image_dir }}"
           MATRIX_CHANGED="${{ matrix.changed }}"
+          HASTELIB_CHANGED="${{ needs.detect-changes.outputs.hastelib }}"
           if [[ "$EVENT" == "workflow_dispatch" ]]; then
             if [[ "$INPUT" == "all" || "$INPUT" == "$MATRIX_IMAGE" ]]; then
               echo "run=true" >> "$GITHUB_OUTPUT"
             else
               echo "run=false" >> "$GITHUB_OUTPUT"
             fi
-          elif [[ "$EVENT" == "pull_request" && "$MATRIX_CHANGED" == "true" ]]; then
+          elif [[ "$EVENT" == "pull_request" && \
+                  "$MATRIX_CHANGED" == "true" && \
+                  "$HASTELIB_CHANGED" != "true" ]]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # Dependabot PRs don't receive repo Actions secrets, so the regular
-      # push path can't run. Build locally on the runner instead — this still
-      # catches dep-resolver conflicts and missing system libs, which is the
-      # signal we want for "is this bump safe to merge as-is?". Deeper
-      # validation happens via the batch-review of Dependabot PRs.
       - name: Build image locally (Dependabot PRs)
         if: steps.resolve.outputs.run == 'true' && github.actor == 'dependabot[bot]'
         shell: bash
@@ -99,7 +103,7 @@ jobs:
 
       - name: Azure Login
         if: steps.resolve.outputs.run == 'true' && github.actor != 'dependabot[bot]'
-        uses: azure/login@v2
+        uses: azure/login@1384c340ab2dda50fed2bee3041d1d87018aa5e8 # v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -117,7 +121,6 @@ jobs:
           echo "Building with IMAGE_DIR=$IMAGE_DIR and IMAGE_TAG=$IMAGE_TAG"
           bash .github/scripts/build_and_push_images.sh -i "$IMAGE_DIR" -t "$IMAGE_TAG" -a "$ACR_NAME"
 
-  # Always-green gate so branch protection passes even when no images needed rebuilding
   docker-build-gate:
     needs: build-and-push
     runs-on: ubuntu-latest

--- a/.github/workflows/hastegeo-build.yml
+++ b/.github/workflows/hastegeo-build.yml
@@ -1,0 +1,131 @@
+name: Build hastegeo wheel
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "hastelib/**"
+      - ".github/scripts/resolve_hastegeo_version.py"
+      - ".github/scripts/publish_hastegeo_wheel.py"
+      - ".github/workflows/hastegeo-build.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "hastelib/**"
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: "Build channel"
+        required: true
+        default: "rc"
+        type: choice
+        options:
+          - rc
+          - release
+      bump:
+        description: "Version bump when set_version is blank"
+        required: true
+        default: "patch"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      set_version:
+        description: "Optional exact X.Y.Z or (for RC) X.Y.ZrcN"
+        required: false
+        default: ""
+        type: string
+
+# This workflow is intentionally credential-free. The trusted
+# workflow_run publisher lives in hastegeo-publish.yml on the default branch.
+permissions:
+  contents: read
+
+jobs:
+  resolve-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      wheel_name: ${{ steps.resolve.outputs.wheel_name }}
+      channel: ${{ steps.resolve.outputs.channel }}
+      source_sha: ${{ steps.resolve.outputs.source_sha }}
+      already_published: ${{ steps.resolve.outputs.already_published }}
+    steps:
+      - name: Checkout source without persisted credentials
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+
+      - name: Resolve version
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          CHANNEL: ${{ github.event.inputs.channel || (github.event_name == 'pull_request' && 'rc' || 'release') }}
+          BUMP: ${{ github.event.inputs.bump || 'patch' }}
+          SET_VERSION: ${{ github.event.inputs.set_version || '' }}
+        run: |
+          python .github/scripts/resolve_hastegeo_version.py \
+            --channel "$CHANNEL" \
+            --source-sha "$SOURCE_SHA" \
+            --bump "$BUMP" \
+            --set-version "$SET_VERSION"
+
+  build-wheel:
+    needs: resolve-version
+    if: needs.resolve-version.outputs.already_published != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source without persisted credentials
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.resolve-version.outputs.source_sha }}
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+
+      - name: Install pinned build frontend
+        run: python -m pip install "build==1.3.0"
+
+      - name: Run release-policy unit tests
+        run: python -m unittest discover -s hastelib/tests/build -v
+
+      - name: Build wheel
+        working-directory: hastelib
+        env:
+          HASTE_SET_VERSION: ${{ needs.resolve-version.outputs.version }}
+        run: python -m build --wheel
+
+      - name: Validate wheel without GitHub credentials
+        run: |
+          python .github/scripts/publish_hastegeo_wheel.py \
+            --wheel "hastelib/dist/${{ needs.resolve-version.outputs.wheel_name }}" \
+            --expected-version "${{ needs.resolve-version.outputs.version }}" \
+            --channel "${{ needs.resolve-version.outputs.channel }}" \
+            --source-sha "${{ needs.resolve-version.outputs.source_sha }}" \
+            --validate-only
+
+      - name: Upload validated wheel artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: hastegeo-wheel-${{ github.run_id }}
+          if-no-files-found: error
+          retention-days: 7
+          path: hastelib/dist/${{ needs.resolve-version.outputs.wheel_name }}

--- a/.github/workflows/hastegeo-publish.yml
+++ b/.github/workflows/hastegeo-publish.yml
@@ -1,0 +1,327 @@
+name: Publish hastegeo wheel and images
+
+on:
+  workflow_run:
+    workflows:
+      - Build hastegeo wheel
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  prepare:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      (github.event.workflow_run.event == 'push' ||
+       (github.event.workflow_run.event == 'pull_request' &&
+        github.event.workflow_run.head_repository.full_name == github.repository))
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      wheel_name: ${{ steps.resolve.outputs.wheel_name }}
+      channel: ${{ steps.resolve.outputs.channel }}
+      source_sha: ${{ steps.resolve.outputs.source_sha }}
+      already_published: ${{ steps.resolve.outputs.already_published }}
+      pr_number: ${{ steps.guard.outputs.pr_number }}
+    steps:
+      - name: Checkout trusted release policy
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+
+      - name: Verify PR is open and build matches current head
+        id: guard
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT: ${{ github.event.workflow_run.event }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          SOURCE_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          if [ "$EVENT" != "pull_request" ]; then
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::error::Triggering workflow has no PR number"
+            exit 1
+          fi
+          STATE=$(gh pr view "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --json state \
+            --jq '.state')
+          HEAD_SHA=$(gh pr view "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --json headRefOid \
+            --jq '.headRefOid')
+          if [ "$STATE" != "OPEN" ]; then
+            echo "::error::PR #$PR_NUMBER is not open"
+            exit 1
+          fi
+          if [ "$HEAD_SHA" != "$SOURCE_SHA" ]; then
+            echo "::error::PR head changed after the wheel build"
+            exit 1
+          fi
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Re-resolve expected version from trusted policy
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ github.event.workflow_run.head_sha }}
+          CHANNEL: ${{ github.event.workflow_run.event == 'pull_request' && 'rc' || 'release' }}
+        run: |
+          python .github/scripts/resolve_hastegeo_version.py \
+            --channel "$CHANNEL" \
+            --source-sha "$SOURCE_SHA"
+
+      - name: Download wheel artifact
+        if: steps.resolve.outputs.already_published != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          gh run download "$RUN_ID" \
+            --repo "${{ github.repository }}" \
+            --name "hastegeo-wheel-${RUN_ID}" \
+            --dir release-artifact
+
+      - name: Revalidate downloaded wheel
+        if: steps.resolve.outputs.already_published != 'true'
+        run: |
+          python .github/scripts/publish_hastegeo_wheel.py \
+            --wheel "release-artifact/${{ steps.resolve.outputs.wheel_name }}" \
+            --expected-version "${{ steps.resolve.outputs.version }}" \
+            --channel "${{ steps.resolve.outputs.channel }}" \
+            --source-sha "${{ steps.resolve.outputs.source_sha }}" \
+            --validate-only
+
+  publish-rc:
+    needs: prepare
+    if: >-
+      needs.prepare.outputs.channel == 'rc' &&
+      needs.prepare.outputs.already_published != 'true' &&
+      vars.HASTEGEO_RC_PUBLISH_ENABLED != 'false'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: hastegeo-rc-publish
+      cancel-in-progress: false
+    permissions:
+      actions: read
+      contents: write
+    outputs:
+      version: ${{ steps.publish.outputs.published_version }}
+      source_sha: ${{ needs.prepare.outputs.source_sha }}
+      pr_number: ${{ needs.prepare.outputs.pr_number }}
+    steps:
+      - name: Checkout trusted publisher
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+
+      - name: Download wheel artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          gh run download "$RUN_ID" \
+            --repo "${{ github.repository }}" \
+            --name "hastegeo-wheel-${RUN_ID}" \
+            --dir release-artifact
+
+      - name: Publish immutable RC wheel
+        id: publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python .github/scripts/publish_hastegeo_wheel.py \
+            --wheel "release-artifact/${{ needs.prepare.outputs.wheel_name }}" \
+            --expected-version "${{ needs.prepare.outputs.version }}" \
+            --channel rc \
+            --source-sha "${{ needs.prepare.outputs.source_sha }}"
+
+  publish-stable:
+    needs: prepare
+    if: >-
+      needs.prepare.outputs.channel == 'release' &&
+      needs.prepare.outputs.already_published != 'true' &&
+      vars.HASTEGEO_PUBLISH_ENABLED == 'true' &&
+      vars.HASTEGEO_RELEASE_APPROVAL_CONFIGURED == 'true'
+    runs-on: ubuntu-latest
+    environment: hastegeo-release
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Checkout trusted publisher
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+
+      - name: Download wheel artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          gh run download "$RUN_ID" \
+            --repo "${{ github.repository }}" \
+            --name "hastegeo-wheel-${RUN_ID}" \
+            --dir release-artifact
+
+      - name: Publish immutable stable wheel
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python .github/scripts/publish_hastegeo_wheel.py \
+            --wheel "release-artifact/${{ needs.prepare.outputs.wheel_name }}" \
+            --expected-version "${{ needs.prepare.outputs.version }}" \
+            --channel release \
+            --source-sha "${{ needs.prepare.outputs.source_sha }}"
+
+  build-rc-images:
+    needs:
+      - prepare
+      - publish-rc
+    if: >-
+      needs.publish-rc.result == 'success' &&
+      vars.HASTEGEO_RC_ENVIRONMENT != ''
+    runs-on: ubuntu-latest
+    environment: ${{ vars.HASTEGEO_RC_ENVIRONMENT }}
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      matrix:
+        include:
+          - image_dir: training
+            image_name: hastetraining
+          - image_dir: imageryprep
+            image_name: hasteimageryprep
+    steps:
+      - name: Checkout RC source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.prepare.outputs.source_sha }}
+          persist-credentials: false
+
+      - name: Stamp RC version into image source
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          python - <<'PY'
+          import os
+          import re
+          from pathlib import Path
+
+          path = Path("hastelib/src/hastegeo/__about__.py")
+          text = path.read_text(encoding="utf-8")
+          text, count = re.subn(
+              r'^__version__ = ".*"$',
+              f'__version__ = "{os.environ["VERSION"]}"',
+              text,
+              flags=re.MULTILINE,
+          )
+          if count != 1:
+              raise SystemExit("Expected exactly one __version__ assignment")
+          path.write_text(text, encoding="utf-8")
+          PY
+
+      - name: Azure login
+        uses: azure/login@1384c340ab2dda50fed2bee3041d1d87018aa5e8 # v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Build, push, and lock matching RC image
+        env:
+          ACR_NAME: ${{ secrets.ACR_NAME }}
+          IMAGE_DIR: ${{ matrix.image_dir }}
+          IMAGE_NAME: ${{ matrix.image_name }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+          SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        run: |
+          IMAGE_REF="${IMAGE_NAME}:${VERSION}"
+          if IMAGE_JSON=$(az acr repository show \
+              --name "$ACR_NAME" \
+              --image "$IMAGE_REF" \
+              --output json 2>/dev/null); then
+            WRITE_ENABLED=$(echo "$IMAGE_JSON" | \
+              jq -r '.changeableAttributes.writeEnabled')
+            if [ "$WRITE_ENABLED" = "false" ]; then
+              echo "Reusing already locked RC image: $IMAGE_REF"
+              exit 0
+            fi
+            echo "::error::Existing RC image is not locked: $IMAGE_REF"
+            exit 1
+          fi
+          az acr build \
+            --subscription "$SUBSCRIPTION_ID" \
+            --registry "$ACR_NAME" \
+            --image "$IMAGE_REF" \
+            --file "docker/${IMAGE_DIR}/Dockerfile" \
+            .
+          az acr repository update \
+            --name "$ACR_NAME" \
+            --image "$IMAGE_REF" \
+            --write-enabled false \
+            --delete-enabled false
+
+  rc-artifact-summary:
+    needs:
+      - prepare
+      - publish-rc
+      - build-rc-images
+    if: needs.build-rc-images.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Publish matching RC deployment values
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          BODY=$(cat <<EOF
+          ### RC artifacts ready
+
+          All branch deployment references use the same RC tag:
+
+          - \`hastegeo_version\`: \`${VERSION}\`
+          - \`training_image_tag\`: \`${VERSION}\`
+          - \`imageprep_image_tag\`: \`${VERSION}\`
+          - wheel: \`hastegeo-${VERSION}-py3-none-any.whl\`
+          EOF
+          )
+          echo "$BODY" >> "$GITHUB_STEP_SUMMARY"
+          gh pr comment "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --body "$BODY"

--- a/.github/workflows/rc-cleanup.yml
+++ b/.github/workflows/rc-cleanup.yml
@@ -1,0 +1,85 @@
+name: Report or prune RC wheels
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Monday 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: "Delete the reported assets after approval"
+        type: boolean
+        default: false
+      keep:
+        description: "RC wheels to keep per unreleased version"
+        default: "5"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  report:
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event.inputs.apply != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+
+      - name: Report stale RC wheels
+        env:
+          GH_TOKEN: ${{ github.token }}
+          KEEP: ${{ github.event.inputs.keep || '5' }}
+        run: |
+          python .github/scripts/cleanup_rc_releases.py \
+            --keep "$KEEP" \
+            --retain-file .github/rc-retain.txt \
+            | tee rc-cleanup-report.txt
+          {
+            echo "### RC cleanup report"
+            echo ""
+            echo '```text'
+            cat rc-cleanup-report.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  delete:
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.event.inputs.apply == 'true' &&
+      vars.HASTEGEO_PUBLISH_ENABLED == 'true' &&
+      vars.HASTEGEO_RELEASE_APPROVAL_CONFIGURED == 'true'
+    runs-on: ubuntu-latest
+    environment: hastegeo-release
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout trusted cleanup policy
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+
+      - name: Delete approved stale RC wheels
+        env:
+          GH_TOKEN: ${{ github.token }}
+          KEEP: ${{ github.event.inputs.keep || '5' }}
+        run: |
+          python .github/scripts/cleanup_rc_releases.py \
+            --keep "$KEEP" \
+            --retain-file .github/rc-retain.txt \
+            --apply

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,13 +131,12 @@ Three traps worth knowing:
 
 ### Wheel publishing (`hatch build -t wheel`)
 
-`hastelib/haste_build.py` is a Hatchling custom hook that, on every
-wheel build, **bumps the patch in `__about__.py`, uploads to a private
-Azure blob, and rewrites `requirements.txt` pins across the repo**.
-None of that should happen inside a Docker build, so the three
-Dockerfiles that `pip install /tmp/hastelib/` set
-`HASTE_SKIP_VERSION_BUMP=1`. Don't strip that. Only run `hatch build`
-when you genuinely want to cut a release (and have `az login` set up).
+`hastelib/haste_build.py` is build-only. It stamps `HASTE_SET_VERSION`
+when provided and leaves the wheel under `hastelib/dist/`; it never
+queries or mutates GitHub. The CI workflow resolves RC/stable versions,
+builds without write credentials, and passes the wheel to a separate
+approval-gated trusted publisher. Published assets are immutable (no
+clobber), and stable versions are tied to source tags.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ Source for the docs lives in [`docs/`](docs/) and is built with [Jupyter Book](h
   └────────┘  └────────┘  └──────┘  └──────────────┘
 ```
 
-
 ## Components
 
 | Component | Technology | Description |

--- a/api/hastefuncapi/Dockerfile
+++ b/api/hastefuncapi/Dockerfile
@@ -7,17 +7,13 @@ RUN groupadd -r appgroup && useradd -r -g appgroup appuser \
     && mkdir -p /azure-functions-host/Secrets \
     && chown appuser:appgroup /azure-functions-host/Secrets
 
-# Copy files with correct ownership at copy time (avoids chown -R after the fact)
-COPY --chown=appuser:appgroup hastelib/src/hastegeo /home/site/wwwroot/hastegeo
-COPY --chown=appuser:appgroup hastelib/ /tmp/hastelib/
+# Copy the hastegeo library so requirements.txt can install it editable:
+# `-e ../../hastelib` resolves to /home/hastelib from the /home/site/wwwroot
+# WORKDIR. The local/remote install toggle lives in requirements.txt, so this
+# stays a plain `pip install -r requirements.txt`.
+COPY --chown=appuser:appgroup hastelib/ /home/hastelib/
 COPY --chown=appuser:appgroup api/hastefuncapi/requirements.txt ./
-# Install requirements (includes published hastegeo wheel), then override with local source
-# so that local code changes are reflected without publishing a new wheel.
-# HASTE_SKIP_VERSION_BUMP avoids the haste_build.py hook bumping __about__.py and
-# attempting an Azure blob upload during the image build.
-RUN pip install --no-cache-dir -r requirements.txt \
-    && HASTE_SKIP_VERSION_BUMP=1 pip install --no-cache-dir /tmp/hastelib/ \
-    && rm -rf /tmp/hastelib
+RUN pip install --no-cache-dir -r requirements.txt
 COPY --chown=appuser:appgroup api/hastefuncapi/ .
 
 # Convert line endings and make entrypoint executable

--- a/api/hastefuncapi/requirements.txt
+++ b/api/hastefuncapi/requirements.txt
@@ -20,7 +20,7 @@ requests==2.33.0
 requests-auth==8.0.0
 rasterio==1.3.11
 opencv-python==4.10.0.84
-GDAL @ https://researchlabwuopendata.blob.core.windows.net/haste-binaries/GDAL-3.9.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; sys_platform == 'linux'
+GDAL @ https://github.com/microsoft/haste/releases/download/haste-binaries/GDAL-3.9.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; sys_platform == 'linux'
 shapely==2.0.6
 pyyaml==6.0.2
 boto3==1.36.20
@@ -28,6 +28,9 @@ tensorboard==2.19.0
 tenacity==9.1.2
 typing-extensions==4.14.1
 docker==7.1.0
-# Use wheel for remote, comment out for local Docker (source is copied directly)
-hastegeo @ https://researchlabwuopendata.blob.core.windows.net/haste-binaries/hastegeo-1.0.26-py3-none-any.whl
-# -e ../../hastelib # for local development only
+# hastegeo install source -- the local/remote toggle lives here, not in the
+# Dockerfile. Default is the editable local tree so docker-compose builds from
+# the checked-out source with no wheel publish. CI rewrites this to the wheel
+# line below when building deploy images.
+-e ../../hastelib
+# hastegeo @ https://github.com/microsoft/haste/releases/download/haste-binaries/hastegeo-1.0.26-py3-none-any.whl

--- a/api/hastefuncqueues/Dockerfile
+++ b/api/hastefuncqueues/Dockerfile
@@ -7,17 +7,13 @@ RUN groupadd -r appgroup && useradd -r -g appgroup appuser \
     && mkdir -p /azure-functions-host/Secrets \
     && chown appuser:appgroup /azure-functions-host/Secrets
 
-# Copy files with correct ownership at copy time (avoids chown -R after the fact)
-COPY --chown=appuser:appgroup hastelib/src/hastegeo /home/site/wwwroot/hastegeo
-COPY --chown=appuser:appgroup hastelib/ /tmp/hastelib/
+# Copy the hastegeo library so requirements.txt can install it editable:
+# `-e ../../hastelib` resolves to /home/hastelib from the /home/site/wwwroot
+# WORKDIR. The local/remote install toggle lives in requirements.txt, so this
+# stays a plain `pip install -r requirements.txt`.
+COPY --chown=appuser:appgroup hastelib/ /home/hastelib/
 COPY --chown=appuser:appgroup api/hastefuncqueues/requirements.txt ./
-# Install requirements (includes published hastegeo wheel), then override with local source
-# so that local code changes are reflected without publishing a new wheel.
-# HASTE_SKIP_VERSION_BUMP avoids the haste_build.py hook bumping __about__.py and
-# attempting an Azure blob upload during the image build.
-RUN pip install --no-cache-dir -r requirements.txt \
-    && HASTE_SKIP_VERSION_BUMP=1 pip install --no-cache-dir /tmp/hastelib/ \
-    && rm -rf /tmp/hastelib
+RUN pip install --no-cache-dir -r requirements.txt
 COPY --chown=appuser:appgroup api/hastefuncqueues/ .
 
 USER appuser

--- a/api/hastefuncqueues/README.md
+++ b/api/hastefuncqueues/README.md
@@ -161,7 +161,9 @@ The app ships as a Docker container.
 
 **Base image:** `mcr.microsoft.com/azure-functions/python:4-python3.11`
 
-The container runs as a non-root `appuser`. Local `hastegeo` source is copied in alongside the installed wheel to support development builds. Set `HASTE_SKIP_VERSION_BUMP=1` during the build to prevent version bumping.
+The container runs as a non-root `appuser`. Its requirements default to an
+editable `/home/hastelib` install so local Docker builds use the checked-out
+source. Deployment CI rewrites that requirement to a validated release wheel.
 
 ```bash
 docker build -t hastefuncqueues .

--- a/api/hastefuncqueues/requirements.txt
+++ b/api/hastefuncqueues/requirements.txt
@@ -20,7 +20,7 @@ requests==2.33.0
 requests-auth==8.0.0
 rasterio==1.3.11
 opencv-python==4.10.0.84
-GDAL @ https://researchlabwuopendata.blob.core.windows.net/haste-binaries/GDAL-3.9.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; sys_platform == 'linux'
+GDAL @ https://github.com/microsoft/haste/releases/download/haste-binaries/GDAL-3.9.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; sys_platform == 'linux'
 shapely==2.0.6
 pyyaml==6.0.2
 boto3==1.36.20
@@ -28,6 +28,9 @@ tensorboard==2.19.0
 tenacity==9.1.2
 typing-extensions==4.14.1
 docker==7.1.0
-# Use wheel for remote, comment out for local Docker (source is copied directly)
-hastegeo @ https://researchlabwuopendata.blob.core.windows.net/haste-binaries/hastegeo-1.0.26-py3-none-any.whl
-# -e ../../hastelib # for local development only
+# hastegeo install source -- the local/remote toggle lives here, not in the
+# Dockerfile. Default is the editable local tree so docker-compose builds from
+# the checked-out source with no wheel publish. CI rewrites this to the wheel
+# line below when building deploy images.
+-e ../../hastelib
+# hastegeo @ https://github.com/microsoft/haste/releases/download/haste-binaries/hastegeo-1.0.26-py3-none-any.whl

--- a/docker/README.md
+++ b/docker/README.md
@@ -633,31 +633,46 @@ http://<HOST_IP>:4280
 
 ## Rebuilding the Haste Wheel
 
-The `hastelib/` directory contains the shared Python library (`hastegeo` package) used by
-the API services, imageryprep, and training containers. In the Docker deployment, the
-source is **copied directly** into images (no wheel install needed).
+The `hastelib/` directory holds the shared `hastegeo` package used by the API
+services, imageryprep, and training containers.
 
-However, if deploying to Azure (non-Docker), you'll need a wheel:
+**Local docker-compose builds from source.** The function-app `requirements.txt`
+default to an editable install (`-e ../../hastelib`), so `docker compose build`
+picks up local changes with no wheel publish or `hatch build`. The local/remote
+toggle lives in `requirements.txt`, not the Dockerfiles.
+
+**CI builds one matching RC artifact set.** The hastegeo workflows:
+
+1. Resolves the next PEP 440 RC (`1.0.26rc1`) or stable (`1.0.26`) version.
+2. Builds and tests the wheel in a read-only job with no persisted Git
+   credentials.
+3. Passes the validated wheel as an Actions artifact to a trusted publisher.
+4. Automatically publishes same-repository PR RC wheels without overwriting an
+   existing asset.
+5. Builds training and imageryprep exactly once in ACR, in parallel, with the
+   exact same RC tag (`1.0.26rc1`). Stable releases remain approval-gated.
+
+The deploy workflow swaps the editable line for a verified wheel via
+`.github/scripts/set_hastegeo_source.py` before `func publish`. For an RC
+deployment, `hastegeo_version`, `training_image_tag`, and
+`imageprep_image_tag` must all be the same `X.Y.ZrcN`; blank image-tag inputs
+default to the resolved wheel version.
+
+To build a wheel locally (this does not publish):
 
 ```bash
 cd hastelib
+# Build a specific version for local validation:
+HASTE_SET_VERSION=1.0.26rc1 hatch build -t wheel
 
-# Build the wheel (auto-bumps version, uploads to blob, updates requirements.txt)
-python haste_build.py
-
-# Or build manually without the custom script:
-pip install build hatchling
-python -m build --wheel
+# Or build the explicit local-development version (0.0.0+local):
+hatch build -t wheel
 ```
 
-The custom `haste_build.py` script:
-1. Increments the version in `src/hastegeo/__about__.py`
-2. Builds a `.whl` file under `hastelib/dist/`
-3. Uploads it to `researchlabwuopendata.blob.core.windows.net/haste-binaries/` (requires `az login`) and removes the local copy from `hastelib/dist/`
-4. Rewrites the `hastegeo @ <url>` line in `api/hastefuncapi/requirements.txt`, `api/hastefuncqueues/requirements.txt`, and `docker/imageryprep/requirements.txt` so they pin the new wheel URL
-
-> **For local Docker**, you do NOT need to rebuild the wheel — the Dockerfiles
-> copy the source directly with `COPY hastelib/src/hastegeo /home/site/wwwroot/hastegeo`.
+Version resolution is implemented in
+`.github/scripts/resolve_hastegeo_version.py`. Default is the latest stable
+release plus one patch; workflow inputs support minor/major or exact-version
+overrides. The Hatch hook only stamps the explicit version and builds.
 
 ---
 

--- a/docker/imageryprep/requirements.txt
+++ b/docker/imageryprep/requirements.txt
@@ -18,7 +18,7 @@ email_validator==2.3.0
 psycopg2-binary==2.9.9
 requests==2.33.0
 requests-auth==8.0.0
-GDAL @ https://researchlabwuopendata.blob.core.windows.net/haste-binaries/GDAL-3.9.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+GDAL @ https://github.com/microsoft/haste/releases/download/haste-binaries/GDAL-3.9.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 rasterio==1.3.11
 opencv-python==4.10.0.84
 shapely==2.0.6
@@ -31,4 +31,4 @@ pyarrow==23.0.1
 fiona==1.10.1
 fsspec==2024.10.0
 adlfs==2024.12.0
-hastegeo @ https://researchlabwuopendata.blob.core.windows.net/haste-binaries/hastegeo-1.0.26-py3-none-any.whl
+# hastegeo source is copied into the image by docker/imageryprep/Dockerfile.

--- a/docs/api/hastefuncqueues.md
+++ b/docs/api/hastefuncqueues.md
@@ -160,7 +160,9 @@ The app ships as a Docker container.
 
 **Base image:** `mcr.microsoft.com/azure-functions/python:4-python3.11`
 
-The container runs as a non-root `appuser`. Local `hastegeo` source is copied in alongside the installed wheel to support development builds. Set `HASTE_SKIP_VERSION_BUMP=1` during the build to prevent version bumping.
+The container runs as a non-root `appuser`. Its requirements default to an
+editable `/home/hastelib` install so local Docker builds use the checked-out
+source. Deployment CI rewrites that requirement to a validated release wheel.
 
 ```bash
 docker build -t hastefuncqueues .

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@
 #   docs/.venv/Scripts/activate          (Windows)
 #   source docs/.venv/bin/activate       (Linux/Mac)
 #   pip install -r docs/requirements.txt
-#   pip install --no-deps hastegeo @ https://researchlabwuopendata.blob.core.windows.net/haste-binaries/hastegeo-1.0.25-py3-none-any.whl
+#   pip install --no-deps "hastegeo @ https://github.com/microsoft/haste/releases/download/haste-binaries/hastegeo-<version>-py3-none-any.whl"
 #   cd docs && jupyter-book build .
 
 # --- Doc tooling ---
@@ -39,7 +39,7 @@ shapely
 
 # NOTE: The haste wheel must be installed separately with --no-deps
 # because its metadata declares gdal==3.9.2 which can't build from source
-# on most platforms. The GDAL whl on blob storage is linux-only.
-# Run:  pip install --no-deps hastegeo @ https://researchlabwuopendata.blob.core.windows.net/haste-binaries/hastegeo-1.0.25-py3-none-any.whl
+# on most platforms. The GDAL wheel on the GitHub release is linux-only.
+# Run:  pip install --no-deps "hastegeo @ https://github.com/microsoft/haste/releases/download/haste-binaries/hastegeo-<version>-py3-none-any.whl"
 #
 # osgeo/gdal, rasterio, and opencv-python are mocked in conf.py.

--- a/hastelib/README.md
+++ b/hastelib/README.md
@@ -13,8 +13,24 @@
 ## Installation
 
 ```console
-pip install hastegeo
+pip install "hastegeo @ https://github.com/microsoft/haste/releases/download/haste-binaries/hastegeo-<version>-py3-none-any.whl"
 ```
+
+For local development from the repository root:
+
+```console
+pip install -e hastelib/
+```
+
+Local/editable installs report `0.0.0+local`. CI supplies the exact PEP 440
+version when it builds an RC or stable wheel.
+
+## Release process
+
+`hatch build` is build-only. GitHub Actions resolves the version, builds and
+tests without write credentials, then passes the wheel to a separate trusted
+publisher behind the protected `hastegeo-release` environment. Stable releases
+create a `hastegeo-vX.Y.Z` source tag so reruns are idempotent.
 
 ## License
 

--- a/hastelib/haste_build.py
+++ b/hastelib/haste_build.py
@@ -1,259 +1,90 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
+"""Hatch build hook for stamping an explicitly resolved hastegeo version.
+
+Version selection and GitHub publication deliberately live outside this hook.
+Pull-request source executes the hook while building a wheel, so it must never
+receive or use repository write credentials.
+"""
+
 import os
-import re
+from pathlib import Path
+from typing import Any
 
-from azure.storage.blob import BlobServiceClient
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
-
-ACCOUNT_URL = "https://researchlabwuopendata.blob.core.windows.net"
-CONTAINER_NAME = "haste-binaries"
-# Matches the version in a wheel filename, e.g. "hastegeo-1.0.19-py3-none-any.whl"
-WHEEL_VERSION_RE = re.compile(r"^hastegeo-(\d+)\.(\d+)\.(\d+)")
 
 
 class CustomBuildHook(BuildHookInterface):
+    """Stamp the requested version before build and expose the built artifact."""
+
     PLUGIN_NAME = "haste_build"
-    """Custom build hook to bump the package version and copy the built wheel
-    to the required directories."""
 
     def get_plugin_name(self) -> str:
-        """Return the name of the plugin."""
         return self.PLUGIN_NAME
 
     def get_plugin_type(self) -> str:
-        """Return the type of the plugin."""
         return "haste_hook"
 
     def get_plugin_description(self) -> str:
-        """Return the description of the plugin."""
-        return "Custom build hook to handle special build steps."
+        return "Stamp an explicit hastegeo version before packaging."
 
     def get_plugin_author(self) -> str:
-        """Return the author of the plugin."""
-        return "Meygha Machado"
+        return "HASTE Maintainers"
 
     def get_plugin_license(self) -> str:
-        """Return the license of the plugin."""
         return "MIT"
 
-    def _get_container_client(self):
-        """Return an authenticated client for the haste-binaries container."""
-        from azure.identity import AzureCliCredential
-
-        # Use AzureCliCredential specifically to match Azure CLI behavior
-        credential = AzureCliCredential()
-        blob_service_client = BlobServiceClient(
-            account_url=ACCOUNT_URL, credential=credential
-        )
-        return blob_service_client.get_container_client(CONTAINER_NAME)
-
-    def get_latest_published_version(self):
-        """Return the highest (major, minor, patch) tuple already published to
-        blob storage, or None if nothing is found or the listing fails."""
-        try:
-            container_client = self._get_container_client()
-            versions = []
-            for blob in container_client.list_blobs(
-                name_starts_with="hastegeo-"
-            ):
-                match = WHEEL_VERSION_RE.match(blob.name)
-                if match:
-                    versions.append(tuple(int(x) for x in match.groups()))
-
-            if not versions:
-                print("No published hastegeo wheels found in blob storage.")
-                return None
-
-            latest = max(versions)
-            print(
-                "Latest published version in blob storage: "
-                f"{'.'.join(map(str, latest))}"
-            )
-            return latest
-        except Exception as e:
-            print(f"Could not list blob storage versions: {e}")
-            return None
-
-    def upload_to_blob_storage(self, file_path: str, blob_name: str) -> str:
-        """Upload file to Azure blob storage and return the URL."""
-        try:
-            container_client = self._get_container_client()
-            blob_client = container_client.get_blob_client(blob_name)
-
-            # Upload file
-            with open(file_path, "rb") as data:
-                blob_client.upload_blob(data, overwrite=True)
-
-            # Return the public URL
-            blob_url = f"{ACCOUNT_URL}/{CONTAINER_NAME}/{blob_name}"
-            print(
-                f"Successfully uploaded {blob_name} to blob storage: {blob_url}"
-            )
-            return blob_url
-
-        except Exception as e:
-            print(f"Failed to upload to blob storage: {e}")
-            print("Falling back to local file copy...")
-            return None
-
     def _write_version_file(self, version_str: str) -> None:
-        """Persist the resolved version to __about__.py so that source/Docker
-        installs (which build from this tree) report the published version."""
-        version_file_path = os.path.join(
-            self.root, "src", "hastegeo", "__about__.py"
-        )
-        with open(version_file_path, "r") as version_file:
-            lines = version_file.readlines()
-        for i, line in enumerate(lines):
+        version_path = Path(self.root) / "src" / "hastegeo" / "__about__.py"
+        lines = version_path.read_text(encoding="utf-8").splitlines()
+        for index, line in enumerate(lines):
             if line.startswith("__version__"):
-                lines[i] = f'__version__ = "{version_str}"\n'
+                lines[index] = f'__version__ = "{version_str}"'
                 break
-        with open(version_file_path, "w") as version_file:
-            version_file.writelines(lines)
-        print(f"Wrote version {version_str} to {version_file_path}")
-
-    def initialize(self, version, build_data):
-        """Pre build activities"""
-        if version == "editable":
-            print("Editable build detected. Skipping version bump.")
-            return
-        if os.getenv("HASTE_SKIP_VERSION_BUMP"):
-            print("HASTE_SKIP_VERSION_BUMP set, skipping auto-increment.")
-            return
-
-        # Explicit version override always wins, e.g. HASTE_SET_VERSION=2.0.0
-        explicit = os.getenv("HASTE_SET_VERSION")
-        if explicit:
-            self.metadata._version = explicit.strip()
-            self._write_version_file(self.metadata.version)
-            print(
-                f"Set package version to: {self.metadata.version} "
-                "(HASTE_SET_VERSION)"
-            )
-            return
-
-        # Base the next version on the highest version already published to
-        # blob storage so we never overwrite an existing wheel. Fall back to
-        # the local __about__.py version if the listing is unavailable.
-        base = self.get_latest_published_version()
-        if base is None:
-            base = tuple(map(int, self.metadata.version.split(".")))
-            print(f"Falling back to local version: {'.'.join(map(str, base))}")
-        major, minor, patch = base
-
-        bump = os.getenv("HASTE_BUMP", "patch").strip().lower()
-        if bump == "major":
-            new_version = (major + 1, 0, 0)
-        elif bump == "minor":
-            new_version = (major, minor + 1, 0)
-        elif bump == "patch":
-            new_version = (major, minor, patch + 1)
         else:
-            raise ValueError(
-                f"Invalid HASTE_BUMP value: {bump!r} "
-                "(expected 'major', 'minor', or 'patch')"
-            )
+            raise RuntimeError(f"__version__ not found in {version_path}")
+        version_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        print(f"Wrote version {version_str} to {version_path}")
 
-        self.metadata._version = ".".join(map(str, new_version))
-        # Persist before the wheel is assembled so the bundled __about__.py
-        # matches the wheel metadata and any source/Docker install agrees.
-        self._write_version_file(self.metadata.version)
-        print(
-            f"Bumped package version to: {self.metadata.version} "
-            f"(bump={bump})"
-        )
+    @staticmethod
+    def _emit_output(key: str, value: str) -> None:
+        print(f"{key}={value}")
+        output_path = os.getenv("GITHUB_OUTPUT")
+        if output_path:
+            with open(output_path, "a", encoding="utf-8") as handle:
+                handle.write(f"{key}={value}\n")
 
-    def finalize(self, version, build_data, artifact):
-        """Perform actions after the build process."""
+    def initialize(self, version: str, build_data: dict[str, Any]) -> None:
         if version == "editable":
-            print("Editable build detected. Skipping wheel file updates.")
+            print("Editable build detected; keeping the local source version.")
             return
-        if os.getenv("HASTE_SKIP_VERSION_BUMP"):
+
+        explicit_version = os.getenv("HASTE_SET_VERSION")
+        if not explicit_version:
             print(
-                "HASTE_SKIP_VERSION_BUMP set, skipping wheel publish and "
-                "requirements rewrite."
+                "HASTE_SET_VERSION is not set; building the committed local "
+                f"version {self.metadata.version}."
             )
             return
 
-        # __about__.py was already updated to the resolved version in
-        # initialize() (before the wheel was assembled), so nothing to do here.
+        explicit_version = explicit_version.strip()
+        self.metadata._version = explicit_version
+        self._write_version_file(self.metadata.version)
+        print(f"Set package version to {self.metadata.version}.")
 
-        build_dir = "dist"
-        wheel_file = None
-
-        # Find the built wheel file
-        for file_name in os.listdir(build_dir):
-            if file_name.endswith(".whl") and file_name.startswith(
-                "hastegeo-"
-            ):
-                wheel_file = file_name
-                break
-
-        if not wheel_file:
-            print("No haste wheel file found in build directory!")
+    def finalize(
+        self,
+        version: str,
+        build_data: dict[str, Any],
+        artifact: str,
+    ) -> None:
+        if version == "editable":
             return
 
-        wheel_path = os.path.join(build_dir, wheel_file)
+        artifact_path = Path(artifact)
+        if not artifact_path.is_file():
+            raise RuntimeError(f"Built wheel not found: {artifact_path}")
 
-        # Try to upload to blob storage first
-        blob_url = self.upload_to_blob_storage(wheel_path, wheel_file)
-
-        # Update the associated requirements.txt files to use the new version.
-        # If upload fails, keep existing references unchanged to avoid invalid paths.
-        wheel_reference = f"hastegeo @ {blob_url}" if blob_url else None
-
-        if wheel_reference is None:
-            print(
-                "Blob upload failed; skipping requirements.txt haste reference updates."
-            )
-            return
-
-        requirements_files = [
-            "../api/hastefuncapi/requirements.txt",
-            "../api/hastefuncqueues/requirements.txt",
-            "../docker/imageryprep/requirements.txt",
-        ]
-
-        for requirements_file in requirements_files:
-            if not os.path.exists(requirements_file):
-                print(f"Requirements file not found: {requirements_file}")
-                continue
-
-            with open(requirements_file, "r") as file:
-                lines = file.readlines()
-
-            with open(requirements_file, "w") as file:
-                for line in lines:
-                    if line.strip().startswith("haste") and (
-                        "@" in line or "haste-" in line
-                    ):
-                        # Replace existing haste reference with new blob URL
-                        file.write(f"{wheel_reference}\n")
-                        print(
-                            f"Updated haste reference in {requirements_file}"
-                        )
-                    else:
-                        file.write(line)
-
-        # Update env.yml to also use blob URL for consistency
-        env_yml_path = "../env.yml"
-        if os.path.exists(env_yml_path):
-            with open(env_yml_path, "r") as file:
-                lines = file.readlines()
-
-            with open(env_yml_path, "w") as file:
-                for line in lines:
-                    if "haste" in line and (
-                        "@" in line or "haste-" in line and ".whl" in line
-                    ):
-                        # Use blob URL for env.yml as well for consistency
-                        yaml_line = f"    - {wheel_reference}\n"
-                        file.write(yaml_line)
-                        print(f"Updated haste reference in {env_yml_path}")
-                    else:
-                        file.write(line)
-
-        print("Cleaning up the build directory")
-        os.remove(wheel_path)
-        print(f"Removed {wheel_file} from {build_dir}")
+        self._emit_output("built_version", self.metadata.version)
+        self._emit_output("wheel_name", artifact_path.name)
+        self._emit_output("wheel_path", str(artifact_path.resolve()))

--- a/hastelib/haste_release.py
+++ b/hastelib/haste_release.py
@@ -1,0 +1,221 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+"""Pure release-version policy shared by hastegeo CI scripts."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+from typing import Callable, Iterable, Sequence
+
+REPOSITORY = "microsoft/haste"
+RELEASE_TAG = "haste-binaries"
+STABLE_ASSET_RE = re.compile(
+    r"^hastegeo-(\d+)\.(\d+)\.(\d+)-py3-none-any\.whl$"
+)
+RC_ASSET_RE = re.compile(
+    r"^hastegeo-(\d+)\.(\d+)\.(\d+)rc(\d+)-py3-none-any\.whl$"
+)
+STABLE_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+RC_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)rc(\d+)$")
+SOURCE_TAG_RE = re.compile(r"^hastegeo-v(\d+\.\d+\.\d+)$")
+
+CommandRunner = Callable[[Sequence[str]], str]
+
+
+@dataclass(frozen=True)
+class Resolution:
+    """Resolved version and publication state."""
+
+    version: str
+    wheel_name: str
+    channel: str
+    source_sha: str
+    source_tag: str
+    already_published: bool
+
+
+def run_command(command: Sequence[str]) -> str:
+    """Run a command and return stdout, failing closed on any error."""
+    result = subprocess.run(
+        list(command),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def list_release_assets(
+    runner: CommandRunner = run_command,
+) -> list[str]:
+    """Return all asset names from the haste-binaries release."""
+    output = runner(
+        [
+            "gh",
+            "release",
+            "view",
+            RELEASE_TAG,
+            "--repo",
+            REPOSITORY,
+            "--json",
+            "assets",
+            "--jq",
+            ".assets[].name",
+        ]
+    )
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def tags_pointing_at(
+    source_sha: str,
+    runner: CommandRunner = run_command,
+) -> list[str]:
+    """Return hastegeo release tags that point at ``source_sha``."""
+    output = runner(
+        [
+            "git",
+            "tag",
+            "--points-at",
+            source_sha,
+            "--list",
+            "hastegeo-v*",
+        ]
+    )
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def latest_stable(assets: Iterable[str]) -> tuple[int, int, int]:
+    """Return the highest stable version, ignoring RC assets."""
+    versions = []
+    for asset in assets:
+        match = STABLE_ASSET_RE.fullmatch(asset)
+        if match:
+            versions.append(tuple(int(part) for part in match.groups()))
+    if not versions:
+        raise ValueError(
+            "No stable hastegeo wheel exists; use --set-version for the "
+            "initial release."
+        )
+    return max(versions)
+
+
+def bump_version(
+    version: tuple[int, int, int], bump: str
+) -> tuple[int, int, int]:
+    """Apply a semantic version bump."""
+    major, minor, patch = version
+    if bump == "major":
+        return major + 1, 0, 0
+    if bump == "minor":
+        return major, minor + 1, 0
+    if bump == "patch":
+        return major, minor, patch + 1
+    raise ValueError(f"Unsupported bump: {bump!r}")
+
+
+def parse_set_version(
+    value: str, channel: str
+) -> tuple[tuple[int, int, int], int | None]:
+    """Parse an exact stable target or an exact RC override."""
+    stable = STABLE_VERSION_RE.fullmatch(value)
+    if stable:
+        return tuple(int(part) for part in stable.groups()), None
+
+    rc = RC_VERSION_RE.fullmatch(value)
+    if rc and channel == "rc":
+        return tuple(int(part) for part in rc.groups()[:3]), int(rc.group(4))
+
+    raise ValueError(
+        f"Invalid --set-version {value!r} for channel {channel!r}; use "
+        "X.Y.Z or, for RC builds, X.Y.ZrcN."
+    )
+
+
+def next_rc(assets: Iterable[str], target: tuple[int, int, int]) -> int:
+    """Return one more than the highest RC number for ``target``."""
+    numbers = []
+    for asset in assets:
+        match = RC_ASSET_RE.fullmatch(asset)
+        if not match:
+            continue
+        asset_target = tuple(int(part) for part in match.groups()[:3])
+        if asset_target == target:
+            numbers.append(int(match.group(4)))
+    return max(numbers, default=0) + 1
+
+
+def stable_tag_version(tags: Iterable[str]) -> str:
+    """Return the one stable version tagged at a source SHA, if present."""
+    versions = []
+    for tag in tags:
+        match = SOURCE_TAG_RE.fullmatch(tag)
+        if match:
+            versions.append(match.group(1))
+    if len(versions) > 1:
+        raise ValueError(
+            "Multiple hastegeo stable tags point at the same source SHA: "
+            + ", ".join(sorted(versions))
+        )
+    return versions[0] if versions else ""
+
+
+def resolve(
+    *,
+    channel: str,
+    source_sha: str,
+    assets: Sequence[str],
+    tags: Sequence[str],
+    bump: str = "patch",
+    set_version: str = "",
+) -> Resolution:
+    """Resolve a deterministic version from release assets and source tags."""
+    if channel not in {"rc", "release"}:
+        raise ValueError(f"Unsupported channel: {channel!r}")
+    if not source_sha:
+        raise ValueError("source_sha is required")
+
+    if channel == "release":
+        tagged_version = stable_tag_version(tags)
+        if tagged_version:
+            wheel_name = f"hastegeo-{tagged_version}-py3-none-any.whl"
+            return Resolution(
+                version=tagged_version,
+                wheel_name=wheel_name,
+                channel=channel,
+                source_sha=source_sha,
+                source_tag=f"hastegeo-v{tagged_version}",
+                already_published=wheel_name in assets,
+            )
+
+    if set_version:
+        target, explicit_rc = parse_set_version(set_version, channel)
+    else:
+        target = bump_version(latest_stable(assets), bump)
+        explicit_rc = None
+
+    target_text = ".".join(str(part) for part in target)
+    if channel == "rc":
+        rc_number = explicit_rc or next_rc(assets, target)
+        version = f"{target_text}rc{rc_number}"
+        source_tag = ""
+    else:
+        version = target_text
+        source_tag = f"hastegeo-v{version}"
+
+    wheel_name = f"hastegeo-{version}-py3-none-any.whl"
+    if wheel_name in assets:
+        raise ValueError(
+            "Release asset already exists without an idempotent source tag: "
+            f"{wheel_name}"
+        )
+
+    return Resolution(
+        version=version,
+        wheel_name=wheel_name,
+        channel=channel,
+        source_sha=source_sha,
+        source_tag=source_tag,
+        already_published=False,
+    )

--- a/hastelib/pyproject.toml
+++ b/hastelib/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling", "azure-storage-blob==12.23.0", "azure-identity==1.18.0"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.hooks.custom]

--- a/hastelib/src/hastegeo/__about__.py
+++ b/hastelib/src/hastegeo/__about__.py
@@ -1,8 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 #
-# This value is auto-updated at build time to the version resolved from blob
-# storage (see ../../../haste_build.py) so that source/Docker installs report
-# the same version that was published. Committed value tracks the latest
-# published release.
-__version__ = "1.0.26"
+# Local/editable installs intentionally use a development marker. CI supplies
+# HASTE_SET_VERSION when building a release wheel, and the build hook stamps
+# that exact PEP 440 version into the wheel's bundled copy of this file.
+__version__ = "0.0.0+local"

--- a/hastelib/tests/build/test_haste_release.py
+++ b/hastelib/tests/build/test_haste_release.py
@@ -1,0 +1,110 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+HASTELIB_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(HASTELIB_ROOT))
+
+from haste_release import (  # noqa: E402
+    list_release_assets,
+    next_rc,
+    resolve,
+)
+
+
+class HasteReleaseResolutionTests(unittest.TestCase):
+    def test_resolve_rc_ignores_rc_when_selecting_stable_base(self):
+        assets = [
+            "hastegeo-1.0.25-py3-none-any.whl",
+            "hastegeo-9.0.0rc8-py3-none-any.whl",
+        ]
+
+        result = resolve(
+            channel="rc",
+            source_sha="abc",
+            assets=assets,
+            tags=[],
+        )
+
+        self.assertEqual("1.0.26rc1", result.version)
+
+    def test_next_rc_increments_highest_matching_target(self):
+        assets = [
+            "hastegeo-1.0.26rc1-py3-none-any.whl",
+            "hastegeo-1.0.26rc3-py3-none-any.whl",
+            "hastegeo-2.0.0rc9-py3-none-any.whl",
+        ]
+
+        result = next_rc(assets, (1, 0, 26))
+
+        self.assertEqual(4, result)
+
+    def test_resolve_exact_rc_override_preserves_requested_number(self):
+        result = resolve(
+            channel="rc",
+            source_sha="abc",
+            assets=["hastegeo-1.0.25-py3-none-any.whl"],
+            tags=[],
+            set_version="2.0.0rc7",
+        )
+
+        self.assertEqual("2.0.0rc7", result.version)
+
+    def test_resolve_stable_tag_and_asset_is_idempotent(self):
+        result = resolve(
+            channel="release",
+            source_sha="abc",
+            assets=["hastegeo-1.0.26-py3-none-any.whl"],
+            tags=["hastegeo-v1.0.26"],
+        )
+
+        self.assertTrue(result.already_published)
+        self.assertEqual("1.0.26", result.version)
+
+    def test_resolve_stable_tag_without_asset_reuses_same_version(self):
+        result = resolve(
+            channel="release",
+            source_sha="abc",
+            assets=["hastegeo-1.0.25-py3-none-any.whl"],
+            tags=["hastegeo-v1.0.26"],
+        )
+
+        self.assertFalse(result.already_published)
+        self.assertEqual("1.0.26", result.version)
+
+    def test_resolve_existing_asset_without_source_tag_fails(self):
+        with self.assertRaisesRegex(ValueError, "already exists"):
+            resolve(
+                channel="release",
+                source_sha="abc",
+                assets=[
+                    "hastegeo-1.0.25-py3-none-any.whl",
+                    "hastegeo-1.0.26-py3-none-any.whl",
+                ],
+                tags=[],
+                set_version="1.0.26",
+            )
+
+    def test_resolve_without_stable_asset_requires_explicit_version(self):
+        with self.assertRaisesRegex(ValueError, "No stable"):
+            resolve(
+                channel="rc",
+                source_sha="abc",
+                assets=[],
+                tags=[],
+            )
+
+    def test_release_query_failure_propagates(self):
+        def failing_runner(_command):
+            raise subprocess.CalledProcessError(1, "gh")
+
+        with self.assertRaises(subprocess.CalledProcessError):
+            list_release_assets(runner=failing_runner)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hastelib/tests/build/test_release_scripts.py
+++ b/hastelib/tests/build/test_release_scripts.py
@@ -1,0 +1,288 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import sys
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS_ROOT = REPO_ROOT / ".github" / "scripts"
+sys.path.insert(0, str(SCRIPTS_ROOT))
+
+import cleanup_rc_releases  # noqa: E402
+import publish_hastegeo_wheel  # noqa: E402
+import resolve_hastegeo_deploy  # noqa: E402
+import set_hastegeo_source  # noqa: E402
+
+
+def create_wheel(
+    directory: Path,
+    version: str,
+    *,
+    metadata_version: str | None = None,
+) -> Path:
+    wheel = directory / f"hastegeo-{version}-py3-none-any.whl"
+    metadata = (
+        "Metadata-Version: 2.1\n"
+        "Name: hastegeo\n"
+        f"Version: {metadata_version or version}\n"
+    )
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr(
+            f"hastegeo-{version}.dist-info/METADATA",
+            metadata,
+        )
+    return wheel
+
+
+class WheelPublisherTests(unittest.TestCase):
+    def test_validate_wheel_accepts_matching_rc_metadata(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            wheel = create_wheel(Path(temp_dir), "1.0.26rc1")
+
+            identity = publish_hastegeo_wheel.validate_wheel(
+                wheel, "1.0.26rc1", "rc"
+            )
+
+        self.assertEqual("1.0.26rc1", identity.version)
+        self.assertEqual(64, len(identity.sha256))
+
+    def test_validate_wheel_rejects_metadata_version_mismatch(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            wheel = create_wheel(
+                Path(temp_dir),
+                "1.0.26rc1",
+                metadata_version="1.0.26rc2",
+            )
+
+            with self.assertRaisesRegex(ValueError, "METADATA version"):
+                publish_hastegeo_wheel.validate_wheel(wheel, "1.0.26rc1", "rc")
+
+    def test_validate_wheel_rejects_stable_version_on_rc_channel(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            wheel = create_wheel(Path(temp_dir), "1.0.26")
+
+            with self.assertRaisesRegex(ValueError, "requires an rcN"):
+                publish_hastegeo_wheel.validate_wheel(wheel, "1.0.26", "rc")
+
+    @patch.object(
+        publish_hastegeo_wheel,
+        "list_release_assets",
+        return_value=["hastegeo-1.0.26rc1-py3-none-any.whl"],
+    )
+    def test_publish_existing_rc_fails_without_clobber(self, _assets):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            wheel = create_wheel(Path(temp_dir), "1.0.26rc1")
+            identity = publish_hastegeo_wheel.validate_wheel(
+                wheel, "1.0.26rc1", "rc"
+            )
+
+            with self.assertRaisesRegex(ValueError, "will not be overwritten"):
+                publish_hastegeo_wheel.publish(
+                    identity,
+                    channel="rc",
+                    source_sha="abc",
+                )
+
+    @patch.object(
+        publish_hastegeo_wheel,
+        "list_release_assets",
+        return_value=["hastegeo-1.0.26-py3-none-any.whl"],
+    )
+    def test_publish_rc_fails_after_stable_release_exists(self, _assets):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            wheel = create_wheel(Path(temp_dir), "1.0.26rc3")
+            identity = publish_hastegeo_wheel.validate_wheel(
+                wheel, "1.0.26rc3", "rc"
+            )
+
+            with self.assertRaisesRegex(ValueError, "stable asset"):
+                publish_hastegeo_wheel.publish(
+                    identity,
+                    channel="rc",
+                    source_sha="abc",
+                )
+
+    @patch.object(
+        publish_hastegeo_wheel,
+        "get_tag_sha",
+        return_value="abc",
+    )
+    @patch.object(
+        publish_hastegeo_wheel,
+        "list_release_assets",
+        return_value=["hastegeo-1.0.26-py3-none-any.whl"],
+    )
+    def test_publish_existing_stable_for_same_sha_is_noop(self, _assets, _tag):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            wheel = create_wheel(Path(temp_dir), "1.0.26")
+            identity = publish_hastegeo_wheel.validate_wheel(
+                wheel, "1.0.26", "release"
+            )
+
+            url = publish_hastegeo_wheel.publish(
+                identity,
+                channel="release",
+                source_sha="abc",
+            )
+
+        self.assertTrue(url.endswith(identity.filename))
+
+    @patch.object(
+        publish_hastegeo_wheel,
+        "get_tag_sha",
+        return_value="different-sha",
+    )
+    def test_ensure_stable_tag_rejects_mismatched_source(self, _tag):
+        with self.assertRaisesRegex(ValueError, "points to"):
+            publish_hastegeo_wheel.ensure_stable_tag(
+                "hastegeo-v1.0.26", "expected-sha"
+            )
+
+    @patch.object(publish_hastegeo_wheel, "run_command")
+    @patch.object(publish_hastegeo_wheel, "ensure_stable_tag")
+    @patch.object(
+        publish_hastegeo_wheel,
+        "list_release_assets",
+        side_effect=[
+            [],
+            ["hastegeo-1.0.26-py3-none-any.whl"],
+        ],
+    )
+    def test_publish_stable_creates_tag_then_uploads_without_clobber(
+        self, _assets, ensure_tag, run_command
+    ):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            wheel = create_wheel(Path(temp_dir), "1.0.26")
+            identity = publish_hastegeo_wheel.validate_wheel(
+                wheel, "1.0.26", "release"
+            )
+
+            publish_hastegeo_wheel.publish(
+                identity,
+                channel="release",
+                source_sha="abc",
+            )
+
+        ensure_tag.assert_called_once_with("hastegeo-v1.0.26", "abc")
+        upload_command = run_command.call_args.args[0]
+        self.assertIn("upload", upload_command)
+        self.assertNotIn("--clobber", upload_command)
+
+    @patch.object(publish_hastegeo_wheel, "run_command")
+    @patch.object(
+        publish_hastegeo_wheel,
+        "list_release_assets",
+        side_effect=[[], []],
+    )
+    def test_publish_fails_if_uploaded_asset_is_not_visible(
+        self, _assets, _run_command
+    ):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            wheel = create_wheel(Path(temp_dir), "1.0.26rc1")
+            identity = publish_hastegeo_wheel.validate_wheel(
+                wheel, "1.0.26rc1", "rc"
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "asset is missing"):
+                publish_hastegeo_wheel.publish(
+                    identity,
+                    channel="rc",
+                    source_sha="abc",
+                )
+
+
+class DeployResolverTests(unittest.TestCase):
+    def test_canonicalize_version_removes_rc_zero_padding(self):
+        self.assertEqual(
+            "1.5.0rc2",
+            resolve_hastegeo_deploy.canonicalize_version("1.5.0.rc02"),
+        )
+
+    def test_resolve_deploy_wheel_rejects_missing_asset(self):
+        with self.assertRaisesRegex(ValueError, "does not exist"):
+            resolve_hastegeo_deploy.resolve_deploy_wheel(
+                "1.0.26",
+                ["hastegeo-1.0.25-py3-none-any.whl"],
+            )
+
+
+class RequirementToggleTests(unittest.TestCase):
+    def test_rewrite_is_idempotent_and_has_one_active_source(self):
+        content = (
+            "requests==2.33.0\n"
+            "-e ../../hastelib\n"
+            "# hastegeo @ https://example/old.whl\n"
+            "hastegeo @ https://example/duplicate.whl\n"
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            requirements = Path(temp_dir) / "requirements.txt"
+            requirements.write_text(content, encoding="utf-8")
+
+            set_hastegeo_source.rewrite(
+                str(requirements),
+                "wheel",
+                "https://example/new.whl",
+                "../../hastelib",
+            )
+            set_hastegeo_source.rewrite(
+                str(requirements),
+                "wheel",
+                "https://example/new.whl",
+                "../../hastelib",
+            )
+            lines = requirements.read_text(encoding="utf-8").splitlines()
+
+        active = [
+            line
+            for line in lines
+            if line.startswith("-e ") or line.startswith("hastegeo @ ")
+        ]
+        self.assertEqual(
+            ["hastegeo @ https://example/new.whl"],
+            active,
+        )
+
+
+class CleanupTests(unittest.TestCase):
+    def test_plan_deletions_rejects_negative_keep(self):
+        with self.assertRaisesRegex(ValueError, "non-negative"):
+            cleanup_rc_releases.plan_deletions([], -1, set())
+
+    def test_load_retain_requires_configured_file(self):
+        with self.assertRaises(FileNotFoundError):
+            cleanup_rc_releases._load_retain("missing-retain-file.txt")
+
+    def test_stable_release_removes_rc_except_retained_asset(self):
+        assets = [
+            {
+                "name": "hastegeo-1.0.26-py3-none-any.whl",
+                "apiUrl": "stable",
+            },
+            {
+                "name": "hastegeo-1.0.26rc1-py3-none-any.whl",
+                "apiUrl": "rc1",
+            },
+            {
+                "name": "hastegeo-1.0.26rc2-py3-none-any.whl",
+                "apiUrl": "rc2",
+            },
+        ]
+
+        result = cleanup_rc_releases.plan_deletions(
+            assets,
+            keep=5,
+            retain={"hastegeo-1.0.26rc2-py3-none-any.whl"},
+        )
+
+        self.assertEqual(
+            ["hastegeo-1.0.26rc1-py3-none-any.whl"],
+            [str(asset["name"]) for asset in result],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hastelib/tests/build/test_release_workflows.py
+++ b/hastelib/tests/build/test_release_workflows.py
@@ -1,0 +1,189 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class ReleaseWorkflowPolicyTests(unittest.TestCase):
+    def test_external_actions_are_pinned_to_full_sha(self):
+        workflows = [
+            ".github/workflows/hastegeo-build.yml",
+            ".github/workflows/hastegeo-publish.yml",
+            ".github/workflows/deploy-apps.yml",
+            ".github/workflows/docker-build-and-push.yml",
+            ".github/workflows/rc-cleanup.yml",
+        ]
+
+        failures = []
+        for relative_path in workflows:
+            path = REPO_ROOT / relative_path
+            for line_number, line in enumerate(
+                path.read_text(encoding="utf-8").splitlines(),
+                start=1,
+            ):
+                if "uses:" not in line:
+                    continue
+                reference = line.split("uses:", 1)[1].strip().split()[0]
+                if reference.startswith("./"):
+                    continue
+                if not re.search(r"@[0-9a-f]{40}$", reference):
+                    failures.append(
+                        f"{relative_path}:{line_number}: {reference}"
+                    )
+
+        self.assertEqual([], failures)
+
+    def test_action_shas_match_their_repositories(self):
+        expected = {
+            "actions/setup-node": ("49933ea5288caeca8642d1e84afbd3f7d6820020"),
+            "azure/login": "1384c340ab2dda50fed2bee3041d1d87018aa5e8",
+        }
+        workflows = [
+            ".github/workflows/hastegeo-build.yml",
+            ".github/workflows/hastegeo-publish.yml",
+            ".github/workflows/deploy-apps.yml",
+            ".github/workflows/docker-build-and-push.yml",
+        ]
+
+        failures = []
+        for relative_path in workflows:
+            text = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+            for action, sha in expected.items():
+                for reference in re.findall(
+                    rf"{re.escape(action)}@([0-9a-f]{{40}})", text
+                ):
+                    if reference != sha:
+                        failures.append(
+                            f"{relative_path}: {action}@{reference}"
+                        )
+
+        self.assertEqual([], failures)
+
+    def test_pr_build_job_has_no_write_credentials(self):
+        workflow = (
+            REPO_ROOT / ".github/workflows/hastegeo-build.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("contents: read", workflow)
+        self.assertIn("persist-credentials: false", workflow)
+        self.assertNotIn("contents: write", workflow)
+        self.assertNotIn("id-token: write", workflow)
+
+    def test_privileged_publisher_is_default_branch_workflow_run(self):
+        workflow = (
+            REPO_ROOT / ".github/workflows/hastegeo-publish.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("workflow_run:", workflow)
+        self.assertIn(
+            "ref: ${{ github.event.repository.default_branch }}",
+            workflow,
+        )
+        self.assertNotIn("pull_request:", workflow)
+        self.assertIn(
+            "github.event.workflow_run.head_repository.full_name",
+            workflow,
+        )
+        self.assertIn("PR head changed after the wheel build", workflow)
+        self.assertIn("PR #$PR_NUMBER is not open", workflow)
+
+    def test_rc_is_automatic_but_stable_is_approval_gated(self):
+        workflow = (
+            REPO_ROOT / ".github/workflows/hastegeo-publish.yml"
+        ).read_text(encoding="utf-8")
+        publisher = (
+            REPO_ROOT / ".github/scripts/publish_hastegeo_wheel.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("workflow_run:", workflow)
+        rc_block = workflow.split("  publish-rc:", 1)[1].split(
+            "  publish-stable:", 1
+        )[0]
+        stable_block = workflow.split("  publish-stable:", 1)[1].split(
+            "  build-rc-images:", 1
+        )[0]
+        self.assertNotIn("environment:", rc_block)
+        self.assertIn("HASTEGEO_RC_PUBLISH_ENABLED", rc_block)
+        self.assertIn("environment: hastegeo-release", stable_block)
+        self.assertIn("environment: hastegeo-release", workflow)
+        self.assertIn("contents: write", workflow)
+        self.assertNotIn("--clobber", publisher)
+
+    def test_pr_workflow_does_not_build_images_twice(self):
+        workflow = (
+            REPO_ROOT / ".github/workflows/hastegeo-build.yml"
+        ).read_text(encoding="utf-8")
+        self.assertNotIn("validate-images:", workflow)
+        self.assertNotIn("docker build", workflow)
+
+    def test_rc_images_use_exact_matching_wheel_version(self):
+        workflow = (
+            REPO_ROOT / ".github/workflows/hastegeo-publish.yml"
+        ).read_text(encoding="utf-8")
+        image_block = workflow.split("  build-rc-images:", 1)[1].split(
+            "  rc-artifact-summary:", 1
+        )[0]
+
+        self.assertIn(
+            "Stamp RC version into image source",
+            image_block,
+        )
+        self.assertIn('IMAGE_REF="${IMAGE_NAME}:${VERSION}"', image_block)
+        self.assertNotIn("TAG_PREFIX", image_block)
+        self.assertIn("Reusing already locked RC image", image_block)
+
+    def test_scheduled_cleanup_is_report_only(self):
+        workflow = (REPO_ROOT / ".github/workflows/rc-cleanup.yml").read_text(
+            encoding="utf-8"
+        )
+        report_block = workflow.split("  report:", 1)[1].split("  delete:", 1)[
+            0
+        ]
+        delete_block = workflow.split("  delete:", 1)[1]
+
+        self.assertNotIn("--apply", report_block)
+        self.assertIn("environment: hastegeo-release", delete_block)
+        self.assertIn("--apply", delete_block)
+
+    def test_function_publish_failure_is_not_swallowed(self):
+        deploy_script = (
+            REPO_ROOT / ".github/scripts/deploy_apps.sh"
+        ).read_text(encoding="utf-8")
+
+        self.assertNotIn(
+            "Function deployment completed but health check failed",
+            deploy_script,
+        )
+        self.assertIn("func azure functionapp publish", deploy_script)
+
+    def test_existing_docker_workflow_skips_hastelib_changes(self):
+        workflow = (
+            REPO_ROOT / ".github/workflows/docker-build-and-push.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("'hastelib/**'", workflow)
+        self.assertIn(
+            'HASTELIB_CHANGED="${{ needs.detect-changes.outputs.hastelib }}"',
+            workflow,
+        )
+        self.assertIn('"$HASTELIB_CHANGED" != "true"', workflow)
+        self.assertIn("Build and Push Docker Image", workflow)
+
+    def test_rc_deploy_defaults_all_artifacts_to_same_version(self):
+        workflow = (REPO_ROOT / ".github/workflows/deploy-apps.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn('TRAINING_TAG="${TRAINING_INPUT:-$VERSION}"', workflow)
+        self.assertIn('IMAGEPREP_TAG="${IMAGEPREP_INPUT:-$VERSION}"', workflow)
+        self.assertIn(
+            "RC deployments require matching wheel and image tags",
+            workflow,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/spec/features/hastegeo-ci-pipeline/README.md
+++ b/spec/features/hastegeo-ci-pipeline/README.md
@@ -1,0 +1,77 @@
+# Feature: hastegeo CI build and release pipeline
+
+**Status:** in-progress
+**Author:** HASTE Maintainers
+**Priority:** P1
+
+## Summary
+
+Automate release-candidate and stable `hastegeo` wheel builds while keeping
+untrusted pull-request code separated from GitHub and Azure write credentials.
+The same pipeline publishes coherent Azure Container Registry image tags and
+gives the deployment workflow an exact wheel version to install.
+
+## Motivation
+
+The current manual Hatch hook mixes version resolution, wheel construction,
+and GitHub release mutation. Running that hook from a pull request with a
+write-scoped token creates a supply-chain risk, and remote failures can be
+silently treated as successful builds. The pipeline also needs deterministic
+stable releases, explicit deployable image tags, and a safe RC cleanup path.
+
+If this feature is not completed, PR code can run with repository write
+credentials, stable release reruns can publish additional versions, and failed
+Function deployments can be reported as successful.
+
+## Success Criteria
+
+- [ ] Pull-request source builds run without repository or Azure write
+      credentials.
+- [ ] A trusted default-branch job automatically publishes validated same-repo
+      PR RC wheels without overwriting an existing asset.
+- [ ] Stable releases are idempotent for a source commit through
+      `hastegeo-vX.Y.Z` tags.
+- [ ] RC publication produces coherent, documented ACR image tags.
+- [ ] Function deployment fails on invalid wheels or `func publish` failures.
+- [ ] Scheduled cleanup reports candidates but never deletes automatically.
+- [ ] Unit, packaging, Docker, and workflow tests cover positive and negative
+      behavior.
+
+## HASTE Components Affected
+
+| Component | Impact |
+|---|---|
+| `hastelib/` | Build-only hook, version stamping, packaging tests |
+| `api/hastefuncapi/` | Editable local install; wheel install during deploy |
+| `api/hastefuncqueues/` | Editable local install; wheel install during deploy |
+| `docker/` | Version-coherent RC image tags |
+| `.github/workflows/` | Read-only build, trusted publish, deploy, cleanup |
+| `.github/scripts/` | Version resolver, wheel publisher, cleanup validation |
+
+## Related Specs
+
+| Spec | Relationship |
+|---|---|
+| [Infra IaC migration](../infra-iac-migration/) | Existing GitHub/Azure deployment conventions |
+
+## Document Index
+
+| Document | Purpose | Status |
+|---|---|---|
+| [design.md](design.md) | Security boundary and release contracts | in-progress |
+| [user-stories.md](user-stories.md) | Acceptance criteria and agent map | in-progress |
+| [plan.md](plan.md) | Ordered implementation tasks | in-progress |
+| [test-plan.md](test-plan.md) | Coverage and landing gates | in-progress |
+
+## Decision Log
+
+| Decision | Rationale |
+|---|---|
+| Hatch is build-only | PR-controlled Python never receives a write token |
+| Artifact handoff to trusted publisher | Small least-privilege mutation surface |
+| No `--clobber` | Published wheel URLs are immutable |
+| Stable source tags | Main workflow reruns are idempotent |
+| PEP 440 `rcN` | `rc01` is normalized to `rc1` by Python packaging |
+| Automatic trusted RC publication | Fast dev/test handoff without exposing PR jobs to credentials |
+| Protected stable environment | Human approval limits stable-release blast radius |
+| Scheduled cleanup is report-only | Destructive automation is deferred until observed safely |

--- a/spec/features/hastegeo-ci-pipeline/design.md
+++ b/spec/features/hastegeo-ci-pipeline/design.md
@@ -1,0 +1,147 @@
+# Technical Design: hastegeo CI build and release pipeline
+
+## Overview
+
+The pipeline separates untrusted source execution from trusted repository and
+Azure mutations. A read-only job builds and validates the wheel, passes it as
+an Actions artifact, and a trusted default-branch workflow validates and
+automatically publishes same-repository PR RCs. Stable releases remain
+approval-gated.
+
+## Architecture
+
+```text
+PR source (untrusted)
+  |
+  v
+Build job [contents:read, persist-credentials:false]
+  - resolve version from public release state
+  - hatch build with explicit HASTE_SET_VERSION
+  - tests + wheel metadata validation
+  |
+  v
+Actions artifact: wheel + SHA256 + version + source SHA
+  |
+  v
+Trusted publish job [contents:write, trusted base ref only]
+  - verify same-repo/open/current PR SHA
+  - enforce rc filename policy
+  - validate wheel METADATA and checksum
+  - reject an existing release asset
+  - upload to haste-binaries
+  |
+  +--> ACR Tasks build training + imageryprep ONCE, in parallel
+       tags: X.Y.ZrcN (exact wheel version)
+  |
+  +--> deploy workflow uses the same wheel + both image tags
+
+Stable push:
+  protected hastegeo-release approval
+  -> publish X.Y.Z + create/reconcile hastegeo-vX.Y.Z tag
+```
+
+## New Components
+
+| Component | Path | Responsibility | Technology |
+|---|---|---|---|
+| Version resolver | `.github/scripts/resolve_hastegeo_version.py` | Stable/RC selection and tag idempotency | Python |
+| Wheel validator/publisher | `.github/scripts/publish_hastegeo_wheel.py` | Validate immutable asset and publish it | Python + `gh` |
+| Resolver tests | `hastelib/tests/build/` | Version and publication policy tests | `unittest` |
+
+## Modified Components
+
+| Component | Path | Change |
+|---|---|---|
+| Hatch hook | `hastelib/haste_build.py` | Stamp explicit version; build only |
+| Wheel workflow | `.github/workflows/hastegeo-build.yml` | Split build and publish credentials |
+| Image workflow | `.github/workflows/docker-build-and-push.yml` | Avoid duplicate hastelib builds |
+| Deploy workflow | `.github/workflows/deploy-apps.yml` | Validate exact wheel before Azure mutation |
+| Deploy script | `.github/scripts/deploy_apps.sh` | Propagate Function publish failures |
+| Cleanup | `.github/scripts/cleanup_rc_releases.py` | Fail-closed report/manual deletion |
+
+## Version Contract
+
+- The latest stable release asset is `hastegeo-X.Y.Z-py3-none-any.whl`.
+- Default target is latest stable plus one patch.
+- `HASTE_BUMP=minor|major` and `HASTE_SET_VERSION` remain explicit overrides.
+- PR versions are canonical PEP 440 `X.Y.ZrcN`.
+- Stable versions are `X.Y.Z`.
+- A stable `hastegeo-vX.Y.Z` Git tag points to the source commit.
+- If the current main SHA already has a valid hastegeo tag and asset, the
+  workflow succeeds as a no-op.
+- If the tag exists but the asset is missing, the same version is rebuilt.
+- A tag at a different SHA or an existing mismatched asset is a hard failure.
+
+## Trust Boundaries
+
+### Build job
+
+- `contents: read`
+- `actions/checkout` uses `persist-credentials: false`
+- no `GH_TOKEN`, Azure login, repository secrets, or environment secrets
+- PR code may execute because producing an RC of that code is intentional
+- no Docker image build occurs here; ACR produces the final image once
+
+### Trusted RC publish job
+
+- automatically runs for successful same-repository PR builds
+- verifies the PR is still open and the built SHA is still current
+- downloads the wheel artifact
+- checks out only the trusted default branch for publisher code
+- never imports or executes code from the wheel
+- validates exact filename, ZIP structure, `METADATA`, version, source SHA,
+  checksum, and channel
+- uploads without clobbering
+- publish jobs are serialized, but read-only builds remain concurrent; if two
+  builds chose the same RC, the later publisher fails safely and is rerun to
+  resolve the next RC
+
+### ACR image job
+
+- uses Azure OIDC after RC publication
+- uses the configured RC GitHub Environment
+- does not execute PR-owned shell scripts with Azure credentials
+- submits the PR source context through trusted inline `az acr build` commands
+- Docker build code does not receive the runner's Azure token
+- builds each image once, tags it exactly `X.Y.ZrcN`, and locks the tag
+
+## Deploy Behavior
+
+The workflow accepts an optional `hastegeo_version`. It normalizes the value
+with `packaging.version.Version`, constructs the canonical asset name, and
+verifies the asset exists before Azure login or Function mutation. The deploy
+script rewrites both Function requirements files and treats any non-zero
+`func publish` exit as a deployment failure. For an RC, blank image-tag inputs
+default to `hastegeo_version`; explicitly different RC tags are rejected.
+
+## Cleanup Behavior
+
+Scheduled runs only report deletion candidates. Manual deletion requires the
+protected release environment. `--keep` must be non-negative, the configured
+retain file must exist, and any GitHub query/delete failure aborts the run.
+
+## Error Handling
+
+| Error | Behavior |
+|---|---|
+| GitHub release query fails | Build fails; no local-version fallback |
+| Existing wheel asset | Fail or no-op only when checksum/source identity matches |
+| Concurrent builds choose the same RC | First publish wins; second fails without clobber and is rerun |
+| RC publish races a stable release | RC is rejected when the stable target exists |
+| Invalid wheel filename/METADATA | Publish rejected |
+| Stable tag points elsewhere | Publish rejected |
+| Azure Function publish fails | Workflow fails |
+| Missing retain file | Cleanup fails |
+| Fork PR | Build/test only; no publish or image push |
+
+## Configuration
+
+| Setting | Purpose |
+|---|---|
+| `HASTEGEO_RC_ENVIRONMENT` repository variable | Selects the environment providing RC ACR OIDC/secrets |
+| `HASTEGEO_RC_PUBLISH_ENABLED` repository variable | RC kill switch (`false` disables; absent enables) |
+| `hastegeo-release` environment | Required reviewer approval for stable releases |
+| `HASTEGEO_PUBLISH_ENABLED` repository variable | Stable publication enablement |
+| `HASTEGEO_RELEASE_APPROVAL_CONFIGURED` repository variable | Admin confirmation that required reviewers are active |
+| `HASTE_BUMP` | Patch(default), minor, or major target |
+| `HASTE_SET_VERSION` | Exact version override |

--- a/spec/features/hastegeo-ci-pipeline/plan.md
+++ b/spec/features/hastegeo-ci-pipeline/plan.md
@@ -1,0 +1,40 @@
+# Execution Plan: hastegeo CI build and release pipeline
+
+## Tasks
+
+| Phase | Task | Agent | Status |
+|---|---|---|---|
+| 1 | Merge main and resolve PR conflicts | `backend-dev` | resolved; merge commit pending |
+| 1 | Add feature spec and acceptance criteria | `backend-dev` | complete |
+| 2 | Extract pure version resolver; make Hatch build-only | `backend-dev` | complete |
+| 2 | Add trusted wheel validator/publisher | `backend-dev` | complete |
+| 3 | Split read-only build and trusted publish workflow jobs | `backend-dev` | complete |
+| 3 | Add automatic trusted RC publication | `backend-dev` | in-progress |
+| 3 | Keep protected environment gate for stable releases | `backend-dev` | blocked: repository admin required |
+| 4 | Connect RC publication to coherent ACR image tags | `backend-dev` | complete |
+| 4 | Harden Function wheel resolution and deployment failure handling | `backend-dev` | complete |
+| 5 | Make cleanup report-only and fail-closed | `backend-dev` | complete |
+| 5 | Pin action/tool versions | `backend-dev` | complete |
+| 6 | Add tests and validate Docker/package/workflows | `backend-validation` | targeted tests complete; full suite blocked by pre-existing Azurite Queue auth issue |
+| 6 | Update PR and run pre-landing review | `backend-validation` | pending |
+
+## Dependencies
+
+1. Version resolver precedes wheel validation and workflows.
+2. Trusted publication precedes ACR image integration.
+3. Deploy and cleanup hardening can proceed after the spec.
+4. Tests must cover all scripts before publication is enabled.
+
+## Rollout Gate
+
+Stable publication jobs use `HASTEGEO_PUBLISH_ENABLED == 'true'` and the
+protected `hastegeo-release` environment. They also require
+`HASTEGEO_RELEASE_APPROVAL_CONFIGURED == 'true'`, which an administrator sets
+only after required reviewers are active. Merge with publication disabled,
+inspect the first build artifacts, configure required reviewers, then enable
+and manually approve the first release.
+
+Same-repository PR RCs publish automatically from trusted `workflow_run` code
+and build final development ACR images once. The target environment is selected
+by `HASTEGEO_RC_ENVIRONMENT`. Set
+`HASTEGEO_RC_PUBLISH_ENABLED=false` only as an emergency kill switch.

--- a/spec/features/hastegeo-ci-pipeline/test-plan.md
+++ b/spec/features/hastegeo-ci-pipeline/test-plan.md
@@ -1,0 +1,62 @@
+# Test Plan: hastegeo CI build and release pipeline
+
+## Test Strategy
+
+| Level | Scope | Tool | Goal |
+|---|---|---|---|
+| Unit | Version, wheel policy, toggles, cleanup | `unittest` / pytest runner | Deterministic positive and negative behavior |
+| Package | Wheel filename and METADATA | Hatch + `zipfile` | Exact PEP 440 artifact |
+| Docker | Editable Function install | Docker | Local source path works |
+| Workflow | YAML, permissions, pins, outputs | Static tests | Least privilege and valid wiring |
+| Integration | Automatic trusted RC publication and ACR build | GitHub Actions | Exact matching deployable artifact refs |
+
+## Unit Scenarios
+
+| ID | Scenario | Expected |
+|---|---|---|
+| UT-001 | Stable assets include RCs | Latest stable ignores RCs |
+| UT-002 | RC1 and RC2 exist | Next RC is RC3 |
+| UT-003 | Release query fails | Resolver raises; no fallback |
+| UT-004 | Same SHA has stable tag and asset | No-op |
+| UT-005 | Same SHA has tag but missing asset | Rebuild same version |
+| UT-006 | Tag points to another SHA | Hard failure |
+| UT-007 | RC artifact claims stable filename | Publisher rejects |
+| UT-008 | Filename and METADATA differ | Publisher rejects |
+| UT-009 | Existing asset name | Publisher rejects; no clobber |
+| UT-009a | Stable target exists before RC publish | Publisher rejects the RC |
+| UT-010 | Requirements toggle repeated | One active source line |
+| UT-011 | Cleanup retain file missing | Hard failure |
+| UT-012 | Cleanup keep is negative | Validation failure |
+| UT-013 | Weekly cleanup | Report only, no delete calls |
+| UT-014 | `rc01` deploy input | Canonicalizes to `rc1` |
+
+## Integration Scenarios
+
+| ID | Scenario | Expected |
+|---|---|---|
+| IT-001 | Build `1.0.26rc1` wheel | Filename and METADATA match |
+| IT-002 | Function API Docker build | `hastegeo` loads from `/home/hastelib/src` |
+| IT-003 | Invalid wheel version deploy | Failure before Azure login/mutation |
+| IT-004 | `func publish` exits non-zero | Deployment workflow fails |
+| IT-005 | Same-repo RC run | Wheel and both exact-version ACR tags appear in summary |
+| IT-006 | Main run repeated at same SHA | No second stable version |
+| IT-007 | Single ACR image build | Each Dockerfile builds once after RC publication |
+
+## Workflow Security Assertions
+
+- Build job permissions are `contents: read`.
+- Build checkout sets `persist-credentials: false`.
+- Build job receives no `GH_TOKEN`, Azure secrets, or OIDC permission.
+- Publish job uses `contents: write`, protected environment, and no PR checkout.
+- Image job executes trusted inline Azure commands rather than PR shell scripts.
+- Fork PR condition skips publish and image jobs.
+- Every external action is pinned to a full SHA.
+
+## Sign-off Criteria
+
+- [ ] All unit and package tests pass.
+- [ ] Targeted Function Docker build passes.
+- [ ] Full hastelib regression suite passes.
+- [ ] No release asset was overwritten during testing.
+- [ ] PR is mergeable and required checks are visible.
+- [ ] Pre-landing review reports zero Critical/High findings.

--- a/spec/features/hastegeo-ci-pipeline/user-stories.md
+++ b/spec/features/hastegeo-ci-pipeline/user-stories.md
@@ -1,0 +1,139 @@
+# User Stories: hastegeo CI build and release pipeline
+
+## Personas
+
+| Persona | Description | Key Goals |
+|---|---|---|
+| HASTE contributor | Changes shared backend/library code | Fast, safe PR validation |
+| HASTE maintainer | Reviews and publishes releases | Immutable, reproducible releases |
+| HASTE operator | Deploys Function apps and Batch images | Exact wheel and image versions |
+
+## Stories
+
+### US-001: Build a release candidate safely
+
+**As a** HASTE contributor,
+**I want to** build an RC wheel without write credentials,
+**So that** my PR can be validated without exposing the repository.
+
+**Priority:** P0
+**Component(s):** `hastelib`, `.github/workflows`
+
+**Acceptance Criteria:**
+
+```gherkin
+Given a pull request changes hastelib
+When the wheel build runs
+Then the build job has read-only contents permission and no persisted Git credentials
+And it uploads a validated RC wheel only as an Actions artifact
+```
+
+```gherkin
+Given the PR is from a fork
+When the workflow runs
+Then it builds and tests but does not publish a wheel or image
+```
+
+### US-002: Publish immutable and idempotent wheels
+
+**As a** HASTE maintainer,
+**I want to** approve a trusted publisher,
+**So that** RC and stable assets cannot overwrite prior releases.
+
+**Priority:** P0
+**Component(s):** `.github/scripts`, `.github/workflows`
+
+**Acceptance Criteria:**
+
+```gherkin
+Given a validated artifact from a same-repository PR
+When the trusted publisher runs
+Then it accepts only an rcN filename whose METADATA and checksum match
+And it fails if that asset already exists
+```
+
+```gherkin
+Given a stable build is rerun for the same source SHA
+When hastegeo-vX.Y.Z already points to that SHA
+Then the workflow reuses or no-ops that version instead of incrementing
+```
+
+### US-003: Produce deployable version-coherent artifacts
+
+**As a** HASTE operator,
+**I want to** receive exact wheel and container image versions,
+**So that** I can deploy the code reviewed in the PR.
+
+**Priority:** P0
+**Component(s):** `.github/workflows`, `docker`, `api`
+
+**Acceptance Criteria:**
+
+```gherkin
+Given an RC wheel is published automatically
+When image builds complete
+Then training and imageryprep images use exactly that RC version as their tag
+And the workflow summary contains their full ACR references
+```
+
+```gherkin
+Given a nonexistent or invalid hastegeo version
+When deployment is requested
+Then it fails before any Azure resource is changed
+```
+
+### US-004: Review RC cleanup before deletion
+
+**As a** HASTE maintainer,
+**I want to** review cleanup candidates,
+**So that** an RC still needed by an environment is not deleted automatically.
+
+**Priority:** P1
+**Component(s):** `.github/scripts`, `.github/workflows`
+
+**Acceptance Criteria:**
+
+```gherkin
+Given the weekly cleanup schedule runs
+When stale RCs are found
+Then it reports candidates without deleting assets
+```
+
+```gherkin
+Given a manual delete is approved
+When the retain file is missing or keep is negative
+Then the cleanup fails without deleting anything
+```
+
+## Agent Assignment Map
+
+| Story | Implementing Agent(s) | Validating Agent(s) | Notes |
+|---|---|---|---|
+| US-001 | `backend-dev` | `backend-validation` | Build hook and read-only workflow |
+| US-002 | `backend-dev` | `backend-validation`, `security-validation` | Trusted publisher and tag policy |
+| US-003 | `backend-dev` | `backend-validation` | ACR and Function deployment |
+| US-004 | `backend-dev` | `backend-validation` | Report-first cleanup |
+
+## Agent Workflow Per Phase
+
+| Phase | Lead Agent | Supporting Agents | Validation |
+|---|---|---|---|
+| Version/package core | `backend-dev` | `security` | `backend-validation` |
+| CI/CD integration | `backend-dev` | `security` | `backend-validation`, `security-validation` |
+| Deployment/cleanup | `backend-dev` | `orchestrator` | `backend-validation` |
+
+## Story Map
+
+| Priority | Story | Phase | Implementing Agent | Component |
+|---|---|---|---|---|
+| P0 | US-001 | Build boundary | `backend-dev` | `hastelib`, Actions |
+| P0 | US-002 | Publication | `backend-dev` | Releases, tags |
+| P0 | US-003 | Deployment artifacts | `backend-dev` | ACR, Functions |
+| P1 | US-004 | Cleanup | `backend-dev` | Releases |
+
+## Out of Scope
+
+- Moving wheels from GitHub Releases to a package registry.
+- Automatic deletion during the first release cycle.
+- Conventional-commit semantic version selection.
+- New Azure resources or infrastructure changes.


### PR DESCRIPTION
## Summary

Moves the GDAL and `hastegeo` wheels from legacy Azure Blob hosting to the public [`haste-binaries` GitHub Release](https://github.com/microsoft/haste/releases/tag/haste-binaries), and adds an automated release-candidate pipeline for `hastegeo` changes.

For each `hastelib` release candidate, the pipeline produces one matching deployable set:

```text
hastegeo-X.Y.ZrcN-py3-none-any.whl
hastetraining:X.Y.ZrcN
hasteimageryprep:X.Y.ZrcN
```

## Changes

- Hosts GDAL and stable `hastegeo` wheels on GitHub Releases using anonymous public download URLs.
- Keeps local Function Docker builds on editable checked-out `hastelib` source.
- Makes the Hatch hook build-only; version resolution and publication are handled by tested CI scripts.
- Adds sequential PEP 440 RC versioning with patch/minor/major and exact-version overrides.
- Builds the RC wheel once in a read-only PR job.
- Publishes same-repository PR RC artifacts through a trusted default-branch workflow.
- Builds training and imageryprep images once in ACR, in parallel, using the exact wheel RC as both image tags.
- Prevents duplicate `hastelib` image builds in the existing Docker workflow.
- Defaults deployment image tags to the selected `hastegeo` version and rejects mismatched RC artifact sets.
- Prevents wheel and versioned image tags from being overwritten.
- Makes stable releases idempotent using source tags.
- Adds report-only scheduled RC cleanup with explicit retention support.
- Updates release, deployment, Docker, and contributor documentation.

## Why

Previously, wheel building, publication, and dependency pin updates were coupled together. The initial CI design also built the same large Docker images locally and then rebuilt them in ACR, adding unnecessary wait time.

The new design separates untrusted PR builds from privileged publication while ensuring each expensive Docker image is built only once. The wheel and both images share one version, making the exact artifact set straightforward to deploy and reproduce.

## Security properties

- PR build jobs use read-only repository permissions and no cloud credentials.
- Fork PRs cannot publish artifacts.
- Privileged publication uses workflow definitions from the default branch.
- Wheel filename and package metadata are validated before publication.
- Existing wheel names and mutable versioned image tags are rejected.
- Stable release publication remains separately gated.

## Testing

- Release/version/publisher/workflow unit tests pass.
- Workflow YAML and action pin validation pass.
- Real RC wheel build and metadata validation pass.
- Function, training, and imageryprep Docker builds were smoke-tested.
- Public wheel URLs were tested from a clean Linux container.
- Standard repository security and code scanning checks run on the PR.

## Rollout

The RC build and trusted publication workflows become active after these workflow definitions are available on the default branch. Stable publication remains disabled until the repository's release controls are configured.

Legacy Blob-hosted files are not removed, preserving compatibility for existing external pins during migration.
