### PR TITLE
Prbatero/docs update add demo animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ docker compose -f docker/docker-compose.yml up
 ### See it in action
 
 <p align="center">
-  <img src="assets/haste-animation.webp" alt="HASTE demo" width="100%">
+  <img src="assets/haste-animation.webp" alt="HASTE demo">
 </p>
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -38,9 +38,7 @@ docker compose -f docker/docker-compose.yml up
 ### See it in action
 
 <p align="center">
-  <video src="assets/haste-animation.mp4" autoplay loop muted playsinline width="100%">
-    Your browser does not support embedded video. <a href="assets/haste-animation.mp4">Watch the HASTE demo</a>.
-  </video>
+  <img src="assets/haste-animation.webp" alt="HASTE demo" width="100%">
 </p>
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ docker compose -f docker/docker-compose.yml up
 
 > For Azure-connected development and production deployment, see [Project Setup](#project-setup) below and the [full documentation](https://microsoft.github.io/haste).
 
+### See it in action
+
+<p align="center">
+  <video src="assets/haste-animation.mp4" autoplay loop muted playsinline width="100%">
+    Your browser does not support embedded video. <a href="assets/haste-animation.mp4">Watch the HASTE demo</a>.
+  </video>
+</p>
+
 ## Documentation
 
 Full documentation is published at **[https://microsoft.github.io/haste](https://microsoft.github.io/haste)** and covers:


### PR DESCRIPTION
This pull request adds a new "See it in action" section to the `README.md` to showcase the HASTE demo with an animated image. This helps users quickly visualize the project in action.

Enhancement to project documentation:

* Added a "See it in action" section to `README.md`, including a centered animated demo image (`assets/haste-animation.webp`) to provide a visual overview of HASTE.