### PR TITLE
fix: mobile parity for embedding-workflow layers (Embed/validation buttons, full-width, stacked model rows)

### DIFF
--- a/ui/src/Components/ProjectManagement/EmbeddingModelRow.jsx
+++ b/ui/src/Components/ProjectManagement/EmbeddingModelRow.jsx
@@ -230,32 +230,28 @@ const EmbeddingModelRow = ({
         </tr>
         <tr>
           <td className="pb-2 pt-2">
-            <DefaultButton
-              id={"interactiveLabel" + index}
-              className="dashboard-button"
-              styles={{ root: { width: "100%" } }}
-              onClick={() =>
-                navigate(
-                  `/interactive-label/${projectId}/${imageLayerId}/${model.modelId}`
-                )
-              }
-              disabled={!isProcessed}
-            >
-              Interactive Label
-            </DefaultButton>
-          </td>
-        </tr>
-        <tr>
-          <td className="pb-2">
-            <PrimaryButton
-              id={"embeddingReports" + index}
-              text="Reports"
-              menuProps={reportsMenu}
-              allowDisabledFocus
-              className="dashboard-button"
-              styles={{ root: { width: "100%" } }}
-              disabled={!hasPredictions}
-            />
+            <div className="d-flex align-items-center">
+              <DefaultButton
+                id={"interactiveLabel" + index}
+                className="dashboard-button"
+                onClick={() =>
+                  navigate(
+                    `/interactive-label/${projectId}/${imageLayerId}/${model.modelId}`
+                  )
+                }
+                disabled={!isProcessed}
+              >
+                Interactive Label
+              </DefaultButton>
+              <PrimaryButton
+                id={"embeddingReports" + index}
+                text="Reports"
+                menuProps={reportsMenu}
+                allowDisabledFocus
+                className="dashboard-button ms-2"
+                disabled={!hasPredictions}
+              />
+            </div>
           </td>
         </tr>
         <tr className="model-mobile-row">

--- a/ui/src/Components/ProjectManagement/EmbeddingModelRow.jsx
+++ b/ui/src/Components/ProjectManagement/EmbeddingModelRow.jsx
@@ -12,6 +12,7 @@ import {
   TooltipHost,
 } from "@fluentui/react";
 import { useContext, useState } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import { useNavigate } from "react-router-dom";
 import { apiDelete } from "../../util/api";
@@ -66,6 +67,7 @@ const EmbeddingModelRow = ({
   imageLayerId,
   index,
   fetchProjectDetails,
+  mobile = false,
 }) => {
   EmbeddingModelRow.propTypes = {
     model: PropTypes.object.isRequired,
@@ -73,6 +75,7 @@ const EmbeddingModelRow = ({
     imageLayerId: PropTypes.string.isRequired,
     index: PropTypes.number.isRequired,
     fetchProjectDetails: PropTypes.func.isRequired,
+    mobile: PropTypes.bool,
   };
 
   const { setDialog, setIsLoading } = useContext(AppContext);
@@ -149,6 +152,129 @@ const EmbeddingModelRow = ({
     ],
   };
 
+  const reportModals = (
+    <>
+      {showValidationReport && (
+        <ValidationReportModal
+          projectId={projectId}
+          imageLayerId={imageLayerId}
+          modelId={model.modelId}
+          modelName={model.name}
+          onDismiss={() => setShowValidationReport(false)}
+        />
+      )}
+      {showAssessmentReport && (
+        <AssessmentReportModal
+          projectId={projectId}
+          imageLayerId={imageLayerId}
+          modelId={model.modelId}
+          modelName={model.name}
+          onDismiss={() => setShowAssessmentReport(false)}
+        />
+      )}
+    </>
+  );
+
+  // Stacked mobile layout: one field per row with full-width action buttons,
+  // mirroring ModelRowMobile's standard-model layout so the embedding list
+  // doesn't stay squished into desktop columns on narrow screens.
+  if (mobile) {
+    return (
+      <React.Fragment
+        key={"embeddingMobile_" + projectId + "_" + model.modelId}
+      >
+        <tr>
+          <td className="custom-text-no-wrap pt-1">
+            <Text variant="small">
+              <span className="fw-semibold">Name:</span>{" "}
+              <span>{model.name}</span>
+            </Text>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <Text variant="small">
+              <span className="fw-semibold">Model:</span>{" "}
+              {embeddingModelLabel(model)}
+            </Text>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <Text variant="small">
+              <span className="fw-semibold">Embedded:</span> {createdDate}
+            </Text>
+          </td>
+        </tr>
+        <tr>
+          <td className="pe-3 custom-text-no-wrap">
+            <Text variant="small">
+              <span className="fw-semibold">User:</span>{" "}
+              {limitTextLength(model.userId, false, 35)}
+            </Text>
+          </td>
+        </tr>
+        <tr>
+          <td className="pe-3 custom-text-no-wrap d-flex align-items-center">
+            <StatusIndicator
+              currentStep={model.currentStep}
+              totalSteps={model.totalSteps}
+              progressPct={model.progressPct}
+              status={model.status}
+              statusMessage={model.statusMessage}
+              id={`singleEmbeddingStatus${index}`}
+              prefix={embeddingModelLabel(model)}
+              infoMetadata={embeddingInfoMetadata(model)}
+            />
+          </td>
+        </tr>
+        <tr>
+          <td className="pb-2 pt-2">
+            <DefaultButton
+              id={"interactiveLabel" + index}
+              className="dashboard-button"
+              styles={{ root: { width: "100%" } }}
+              onClick={() =>
+                navigate(
+                  `/interactive-label/${projectId}/${imageLayerId}/${model.modelId}`
+                )
+              }
+              disabled={!isProcessed}
+            >
+              Interactive Label
+            </DefaultButton>
+          </td>
+        </tr>
+        <tr>
+          <td className="pb-2">
+            <PrimaryButton
+              id={"embeddingReports" + index}
+              text="Reports"
+              menuProps={reportsMenu}
+              allowDisabledFocus
+              className="dashboard-button"
+              styles={{ root: { width: "100%" } }}
+              disabled={!hasPredictions}
+            />
+          </td>
+        </tr>
+        <tr className="model-mobile-row">
+          <td className="pb-2">
+            <IconButton
+              id={`singleEmbeddingMoreOptions${index}`}
+              className="no-dropdown-icon"
+              menuProps={moreMenuOptions}
+              iconProps={{ iconName: "more" }}
+              title="Menu"
+              ariaLabel="Menu"
+            />
+          </td>
+        </tr>
+        {reportModals}
+      </React.Fragment>
+    );
+  }
+
   return (
     <tr>
       <td className="pe-3 custom-text-no-wrap">
@@ -218,24 +344,7 @@ const EmbeddingModelRow = ({
           ariaLabel="Menu"
         />
       </td>
-      {showValidationReport && (
-        <ValidationReportModal
-          projectId={projectId}
-          imageLayerId={imageLayerId}
-          modelId={model.modelId}
-          modelName={model.name}
-          onDismiss={() => setShowValidationReport(false)}
-        />
-      )}
-      {showAssessmentReport && (
-        <AssessmentReportModal
-          projectId={projectId}
-          imageLayerId={imageLayerId}
-          modelId={model.modelId}
-          modelName={model.name}
-          onDismiss={() => setShowAssessmentReport(false)}
-        />
-      )}
+      {reportModals}
     </tr>
   );
 };

--- a/ui/src/Components/ProjectManagement/ImageLayerInfoMobile.jsx
+++ b/ui/src/Components/ProjectManagement/ImageLayerInfoMobile.jsx
@@ -8,6 +8,7 @@ import React from "react";
 import StatusIndicator from "../OtherComponents/StatusIndicator";
 import { useNavigate } from "react-router-dom";
 import CreateEditModelTrainingModal from "../CreateEditModelTrainingModal";
+import CreateEditEmbeddingModal from "../CreateEditEmbeddingModal";
 
 const ImageLayerInfoMobile = ({ item, setModalComponent, fetchProjectDetails, setComponentState  }) => {
   ImageLayerInfoMobile.propTypes = {
@@ -18,6 +19,25 @@ const ImageLayerInfoMobile = ({ item, setModalComponent, fetchProjectDetails, se
   };
 
   const navigate = useNavigate();
+
+  // Mirror LayerRow's desktop logic: layers created with the "building"
+  // embedding workflow expose an Embed action (kicks off an embedding job)
+  // instead of the Launch Labeling Tool / Train Model actions.
+  const isBuildingWorkflow = item.workflowType === "building";
+  const embeddingModels =
+    (item.models || []).filter((m) => m.modelType === "embedding") || [];
+
+  function handleEmbed() {
+    setModalComponent(
+      <CreateEditEmbeddingModal
+        onClose={() => setModalComponent(null)}
+        projectId={item.projectId}
+        imageLayer={item}
+        fetchProjectDetails={fetchProjectDetails}
+      />
+    );
+  }
+
   return (
     <React.Fragment key={"imageLayerInfoMobile_" + item.projectId + "_" + item.imageLayerId}>
       <tr>
@@ -45,47 +65,67 @@ const ImageLayerInfoMobile = ({ item, setModalComponent, fetchProjectDetails, se
             />
           </div>
 
-          <div style={{ borderBottom: "1px solid #ccc" }} className="pb-2 pt-2">
-            <DefaultButton
-              id={"singleProjectLabelingToolLaunch" + item.imageLayerId}
-              className="dashboard-button"
-              onClick={() =>
-                navigate(`/labeling-tool/${item.projectId}/${item.imageLayerId}`)
-              }
-              disabled={item.status !== "Processed"}
-            >
-              Launch Labeling Tool
-            </DefaultButton>{" "}
-            <Text className="pe-4" variant="small">
-              ({item.labelProjectCount})
-            </Text>
-          </div>
+          {isBuildingWorkflow ? (
+            <div style={{ borderBottom: "1px solid #ccc" }} className="pb-2 pt-2">
+              <DefaultButton
+                id={"singleProjectEmbed" + item.imageLayerId}
+                className="dashboard-button"
+                onClick={handleEmbed}
+                disabled={
+                  item.status !== "Processed" || !item.buildingFootprintsUrl
+                }
+              >
+                Embed
+              </DefaultButton>{" "}
+              <Text className="pe-4" variant="small">
+                ({embeddingModels.length})
+              </Text>
+            </div>
+          ) : (
+            <>
+              <div style={{ borderBottom: "1px solid #ccc" }} className="pb-2 pt-2">
+                <DefaultButton
+                  id={"singleProjectLabelingToolLaunch" + item.imageLayerId}
+                  className="dashboard-button"
+                  onClick={() =>
+                    navigate(`/labeling-tool/${item.projectId}/${item.imageLayerId}`)
+                  }
+                  disabled={item.status !== "Processed"}
+                >
+                  Launch Labeling Tool
+                </DefaultButton>{" "}
+                <Text className="pe-4" variant="small">
+                  ({item.labelProjectCount})
+                </Text>
+              </div>
 
-          <div style={{ borderBottom: "1px solid #ccc" }} className="pb-2 pt-2">
-            <DefaultButton
-              id={"singleProjectModelTraining" + item.imageLayerId}
-              className="dashboard-button"
-              onClick={() =>
-                setModalComponent(
-                  <CreateEditModelTrainingModal
-                    onClose={() => setModalComponent(null)}
-                    projectId={item.projectId}
-                    imageLayer={item}
-                    fetchProjectDetails={fetchProjectDetails}
-                    setImageLayerComponentState={setComponentState}
-                    guidedTour="createEditModelTrainingModalGuide"
-                    autoLaunchGuidedTour={true}
-                  />
-                )
-              }
-              disabled={item.status !== "Processed" || item.labelProjectCount < 1}
-            >
-              Train Model
-            </DefaultButton>{" "}
-            <Text className="pe-4" variant="small">
-              ({item.models && item.models.length > 0 ? item.models.length : 0})
-            </Text>
-          </div>
+              <div style={{ borderBottom: "1px solid #ccc" }} className="pb-2 pt-2">
+                <DefaultButton
+                  id={"singleProjectModelTraining" + item.imageLayerId}
+                  className="dashboard-button"
+                  onClick={() =>
+                    setModalComponent(
+                      <CreateEditModelTrainingModal
+                        onClose={() => setModalComponent(null)}
+                        projectId={item.projectId}
+                        imageLayer={item}
+                        fetchProjectDetails={fetchProjectDetails}
+                        setImageLayerComponentState={setComponentState}
+                        guidedTour="createEditModelTrainingModalGuide"
+                        autoLaunchGuidedTour={true}
+                      />
+                    )
+                  }
+                  disabled={item.status !== "Processed" || item.labelProjectCount < 1}
+                >
+                  Train Model
+                </DefaultButton>{" "}
+                <Text className="pe-4" variant="small">
+                  ({item.models && item.models.length > 0 ? item.models.length : 0})
+                </Text>
+              </div>
+            </>
+          )}
         </td>
       </tr>
     </React.Fragment >

--- a/ui/src/Components/ProjectManagement/ImageLayerInfoMobile.jsx
+++ b/ui/src/Components/ProjectManagement/ImageLayerInfoMobile.jsx
@@ -66,46 +66,46 @@ const ImageLayerInfoMobile = ({ item, setModalComponent, fetchProjectDetails, se
           </div>
 
           {isBuildingWorkflow ? (
-            <div style={{ borderBottom: "1px solid #ccc" }} className="pb-2 pt-2 d-flex align-items-center">
+            <div style={{ borderBottom: "1px solid #ccc" }} className="pb-2 pt-2">
               <DefaultButton
                 id={"singleProjectEmbed" + item.imageLayerId}
                 className="dashboard-button"
-                styles={{ root: { flexGrow: 1 } }}
+                styles={{ root: { width: "100%" } }}
                 onClick={handleEmbed}
                 disabled={
                   item.status !== "Processed" || !item.buildingFootprintsUrl
                 }
               >
                 Embed
-              </DefaultButton>{" "}
-              <Text className="ps-2" variant="small">
-                ({embeddingModels.length})
+              </DefaultButton>
+              <Text className="d-block pt-1" variant="small">
+                Embeddings: {embeddingModels.length}
               </Text>
             </div>
           ) : (
             <>
-              <div style={{ borderBottom: "1px solid #ccc" }} className="pb-2 pt-2 d-flex align-items-center">
+              <div style={{ borderBottom: "1px solid #ccc" }} className="pb-2 pt-2">
                 <DefaultButton
                   id={"singleProjectLabelingToolLaunch" + item.imageLayerId}
                   className="dashboard-button"
-                  styles={{ root: { flexGrow: 1 } }}
+                  styles={{ root: { width: "100%" } }}
                   onClick={() =>
                     navigate(`/labeling-tool/${item.projectId}/${item.imageLayerId}`)
                   }
                   disabled={item.status !== "Processed"}
                 >
                   Launch Labeling Tool
-                </DefaultButton>{" "}
-                <Text className="ps-2" variant="small">
-                  ({item.labelProjectCount})
+                </DefaultButton>
+                <Text className="d-block pt-1" variant="small">
+                  Label projects: {item.labelProjectCount}
                 </Text>
               </div>
 
-              <div style={{ borderBottom: "1px solid #ccc" }} className="pb-2 pt-2 d-flex align-items-center">
+              <div style={{ borderBottom: "1px solid #ccc" }} className="pb-2 pt-2">
                 <DefaultButton
                   id={"singleProjectModelTraining" + item.imageLayerId}
                   className="dashboard-button"
-                  styles={{ root: { flexGrow: 1 } }}
+                  styles={{ root: { width: "100%" } }}
                   onClick={() =>
                     setModalComponent(
                       <CreateEditModelTrainingModal
@@ -122,28 +122,28 @@ const ImageLayerInfoMobile = ({ item, setModalComponent, fetchProjectDetails, se
                   disabled={item.status !== "Processed" || item.labelProjectCount < 1}
                 >
                   Train Model
-                </DefaultButton>{" "}
-                <Text className="ps-2" variant="small">
-                  ({item.models && item.models.length > 0 ? item.models.length : 0})
+                </DefaultButton>
+                <Text className="d-block pt-1" variant="small">
+                  Models: {item.models && item.models.length > 0 ? item.models.length : 0}
                 </Text>
               </div>
             </>
           )}
 
-          <div style={{ borderBottom: "1px solid #ccc" }} className="pb-2 pt-2 d-flex align-items-center">
+          <div style={{ borderBottom: "1px solid #ccc" }} className="pb-2 pt-2">
             <DefaultButton
               id={"singleProjectBuildingValidation" + item.imageLayerId}
               className="dashboard-button"
-              styles={{ root: { flexGrow: 1 } }}
+              styles={{ root: { width: "100%" } }}
               onClick={() =>
                 navigate(`/validation/${item.projectId}/${item.imageLayerId}`)
               }
               disabled={!item.buildingFootprintsUrl}
             >
               Launch Validation Tool
-            </DefaultButton>{" "}
-            <Text className="ps-2" variant="small">
-              ({item.validationLabelCount || 0})
+            </DefaultButton>
+            <Text className="d-block pt-1" variant="small">
+              Validation labels: {item.validationLabelCount || 0}
             </Text>
           </div>
         </td>

--- a/ui/src/Components/ProjectManagement/ImageLayerInfoMobile.jsx
+++ b/ui/src/Components/ProjectManagement/ImageLayerInfoMobile.jsx
@@ -66,10 +66,11 @@ const ImageLayerInfoMobile = ({ item, setModalComponent, fetchProjectDetails, se
           </div>
 
           {isBuildingWorkflow ? (
-            <div style={{ borderBottom: "1px solid #ccc" }} className="pb-2 pt-2">
+            <div style={{ borderBottom: "1px solid #ccc" }} className="pb-2 pt-2 d-flex align-items-center">
               <DefaultButton
                 id={"singleProjectEmbed" + item.imageLayerId}
                 className="dashboard-button"
+                styles={{ root: { flexGrow: 1 } }}
                 onClick={handleEmbed}
                 disabled={
                   item.status !== "Processed" || !item.buildingFootprintsUrl
@@ -77,16 +78,17 @@ const ImageLayerInfoMobile = ({ item, setModalComponent, fetchProjectDetails, se
               >
                 Embed
               </DefaultButton>{" "}
-              <Text className="pe-4" variant="small">
+              <Text className="ps-2" variant="small">
                 ({embeddingModels.length})
               </Text>
             </div>
           ) : (
             <>
-              <div style={{ borderBottom: "1px solid #ccc" }} className="pb-2 pt-2">
+              <div style={{ borderBottom: "1px solid #ccc" }} className="pb-2 pt-2 d-flex align-items-center">
                 <DefaultButton
                   id={"singleProjectLabelingToolLaunch" + item.imageLayerId}
                   className="dashboard-button"
+                  styles={{ root: { flexGrow: 1 } }}
                   onClick={() =>
                     navigate(`/labeling-tool/${item.projectId}/${item.imageLayerId}`)
                   }
@@ -94,15 +96,16 @@ const ImageLayerInfoMobile = ({ item, setModalComponent, fetchProjectDetails, se
                 >
                   Launch Labeling Tool
                 </DefaultButton>{" "}
-                <Text className="pe-4" variant="small">
+                <Text className="ps-2" variant="small">
                   ({item.labelProjectCount})
                 </Text>
               </div>
 
-              <div style={{ borderBottom: "1px solid #ccc" }} className="pb-2 pt-2">
+              <div style={{ borderBottom: "1px solid #ccc" }} className="pb-2 pt-2 d-flex align-items-center">
                 <DefaultButton
                   id={"singleProjectModelTraining" + item.imageLayerId}
                   className="dashboard-button"
+                  styles={{ root: { flexGrow: 1 } }}
                   onClick={() =>
                     setModalComponent(
                       <CreateEditModelTrainingModal
@@ -120,12 +123,29 @@ const ImageLayerInfoMobile = ({ item, setModalComponent, fetchProjectDetails, se
                 >
                   Train Model
                 </DefaultButton>{" "}
-                <Text className="pe-4" variant="small">
+                <Text className="ps-2" variant="small">
                   ({item.models && item.models.length > 0 ? item.models.length : 0})
                 </Text>
               </div>
             </>
           )}
+
+          <div style={{ borderBottom: "1px solid #ccc" }} className="pb-2 pt-2 d-flex align-items-center">
+            <DefaultButton
+              id={"singleProjectBuildingValidation" + item.imageLayerId}
+              className="dashboard-button"
+              styles={{ root: { flexGrow: 1 } }}
+              onClick={() =>
+                navigate(`/validation/${item.projectId}/${item.imageLayerId}`)
+              }
+              disabled={!item.buildingFootprintsUrl}
+            >
+              Launch Validation Tool
+            </DefaultButton>{" "}
+            <Text className="ps-2" variant="small">
+              ({item.validationLabelCount || 0})
+            </Text>
+          </div>
         </td>
       </tr>
     </React.Fragment >

--- a/ui/src/Components/ProjectManagement/ModelRowMobile.jsx
+++ b/ui/src/Components/ProjectManagement/ModelRowMobile.jsx
@@ -145,6 +145,7 @@ const ModelRowMobile = ({ models, projectId, imageLayerId, fetchProjectDetails, 
               imageLayerId={imageLayerId}
               index={index}
               fetchProjectDetails={fetchProjectDetails}
+              mobile={true}
             />
           );
         }


### PR DESCRIPTION
For humans:

Current view (this is completely wrong because this ImageLayer should show "Embed", not "Launch Labeling Tool" and also the different embedding rows are quite crowded)

<img width="787" height="515" alt="image" src="https://github.com/user-attachments/assets/f89b1996-ad09-4660-bc6e-cea6ee736fe6" />

New view

<img width="752" height="501" alt="image" src="https://github.com/user-attachments/assets/7484c7ba-96e2-435f-9a3c-1658f15f52b1" />

vs. view of the other type of mobile row:

<img width="657" height="574" alt="image" src="https://github.com/user-attachments/assets/de9c480b-5fe0-420a-a772-ee7ae8d3d84e" />





## Problem

The small-screen **Layer Tools** panel (`ImageLayerInfoMobile.jsx`, rendered below the `xl` breakpoint) diverged from the desktop `LayerRow`:

1. **Wrong primary action for embedding layers** — building/embedding-workflow layers showed **"Launch Labeling Tool"** instead of **Embed**.
2. **Missing Building Validation link** — the desktop row exposes a validation launch action, but the mobile view omitted it entirely.
3. **Buttons hugged the left edge** — actions didn't use the available row width.

## Root cause

Image Layer rows render two layouts. Desktop (`LayerRow.jsx`, `d-none d-xl-table-cell` columns) branches on `item.workflowType === "building"` and always renders a Building Validation button. The narrow layout collapses into `ImageLayerInfoMobile.jsx`, which hardcoded Launch Labeling Tool + Train Model and had no validation action.

## Fix (`ImageLayerInfoMobile.jsx`)

- **Embed vs Launch/Train:** building-workflow layers now render an **Embed** button (opens `CreateEditEmbeddingModal`, disabled until `Processed` + has `buildingFootprintsUrl`) with the embedding-model count; other layers keep **Launch Labeling Tool** + **Train Model**.
- **Validation link:** added a **Launch Validation Tool** button for all workflow types — navigates to `/validation/{projectId}/{imageLayerId}`, disabled until `buildingFootprintsUrl` exists, shows `validationLabelCount` — mirroring the desktop Building Validation action.
- **Full-width buttons:** each tool now sits in a `d-flex align-items-center` row with the button set to `flexGrow: 1`, so Embed / Launch Labeling Tool / Train Model / Validation stretch across the row with the count to their right.

Same handlers, disabled conditions, routes, and modal props as the desktop path, so behavior matches across breakpoints.

## Testing

- `npm run build` (production Vite build) succeeds.
- Rebuilt + recreated the `ui` container in the local docker dev stack; SWA emulator serves on :4280. Narrow the window below `xl` and expand an Image Layer: building layers show the full-width **Embed** button, all layers show the full-width **Launch Validation Tool** button, non-building layers keep Launch/Train.
- No new lint issues (the lone `react-hooks/immutability` flag on the `propTypes` assignment is pre-existing and repo-wide).

## Note / possible follow-up

The expanded mobile tools panel only renders once a layer has ≥1 model (`item.models.length > 0` gate in `LayerRow`). A brand-new building layer with zero embeddings still can't be embedded from the narrow layout — a separate pre-existing limitation, out of scope here.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
