### PR TITLE
fix(ci): pull Git LFS in docs Pages build so user-doc videos load

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -25,7 +25,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
+        # Fetch Git LFS objects (docs/_static/**/*.mp4) so the built site
+        # serves real videos, not 132-byte LFS pointer files.
         uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Videos not loading on the HASTE user docs

## Root cause

Docs videos are Git LFS objects (`.gitattributes`: `*.mp4 filter=lfs`). The Pages build (`.github/workflows/docs-deploy.yml`) checked out with `actions/checkout@v4` and no `lfs: true`, so CI only had LFS **pointer** files. Jupyter Book copied those into `_build/html/_static/**`, and Pages served 132-byte "videos".

Proof — the live asset today returns HTTP 200, `content-type: video/mp4`, **content-length: 132**, with this body:

    version https://git-lfs.github.com/spec/v1
    oid sha256:b33de785af72d7b90bda6a7d7092cf0769e1241060e40ac815d31ad37ccfb670
    size 6509272

Images (PNG/JPG) load because they are **not** LFS-tracked.

## Fix

Add `lfs: true` to the docs checkout. One change fixes all 7 videos across `docs/usage/{image-layers,overview,projects}.md`. No changes to docs content or the `.mp4` files.

## Verification

Built the book in an ubuntu `python:3.11-slim` container against the LFS-populated tree (what CI will have with `lfs: true`):

- `_static/usage/imageLayers/image-layers-create-a-new-layer.mp4` = **6,509,272 bytes**, real `ftyp…mp4` binary — not a 132-byte pointer.
- All 7 usage videos emitted at real sizes (0.7–23.7 MB).

Once merged, `docs-deploy` (which triggers on changes to `.github/workflows/docs-deploy.yml` and `docs/**`) redeploys with LFS and the live videos play.

## Notes

- In-app UI help videos are unaffected — `deploy-apps.yml` already runs `git lfs pull`.
- LFS bandwidth per docs build is ~44 MB (7 mp4s); negligible.
