### PR TITLE
docs: link Planet open data for image layer sources

### DIFF
--- a/docs/usage/image-layers.md
+++ b/docs/usage/image-layers.md
@@ -18,9 +18,8 @@ upload them all together and HASTE will combine them into a single mosaic.
 There are multiple providers of satellite imagery for damage assessment, including but
 not limited to the following:
 
+- Planet Disaster Data — <https://source.coop/planet/disasterdata>
 - Vantor Open Data Program — <https://vantor.com/company/open-data-program//>
-- Planet Scope — <https://developers.planet.com/docs/data/planetscope>
-- Planet Skysat — <https://developers.planet.com/docs/data/skysat>
 
 ### Formats
 
@@ -47,7 +46,10 @@ hosts a few public post-disaster samples you can drop straight into an image lay
   the **Building** workflow; the **Standard** workflow doesn't require them.
 
 ```{note}
-The **Black River** set pairs post-event imagery with matching building footprints, so it's a
+The **Black River** post-event image (`black-river_visual_mosaic_cog.tif`) is a mosaic of all
+the individual visual assets in
+[Planet's Hurricane Melissa 2025 Black River disaster data](https://source.coop/planet/disasterdata/hurricane-melissa-2025/post-event/black-river).
+This set pairs post-event imagery with matching building footprints, so it's a
 complete example for {doc}`Rapid Building Assessment <rapid-building-assessment>`. The
 **Lahaina** scene is imagery only — a good fit for {doc}`Damage Mapping <damage-mapping>`,
 where footprints are pulled automatically from Overture Maps.

--- a/ui/src/Components/HelpDocs/HelpDocsImageLayers.jsx
+++ b/ui/src/Components/HelpDocs/HelpDocsImageLayers.jsx
@@ -38,9 +38,8 @@ const HelpDocsImageLayers = ({ anchor }) => {
 
       <p>There are multiple providers of satellite imagery for damage assessment, including but not limited to the following: </p>
       <ul>
-        <li>Maxar Open Data Program <a href="https://www.maxar.com/" target='_blank'>https://www.maxar.com/</a></li>
-        <li>Planet Scope <a href="https://developers.planet.com/docs/data/planetscope" target='_blank'>https://developers.planet.com/docs/data/planetscope</a></li>
-        <li>Planet Skysat <a href="https://developers.planet.com/docs/data/skysat" target='_blank'>https://developers.planet.com/docs/data/skysat</a></li>
+        <li>Planet Disaster Data <a href="https://source.coop/planet/disasterdata" target='_blank'>https://source.coop/planet/disasterdata</a></li>
+        <li>Maxar Open Data Program <a href="https://www.maxar.com/" target='_blank'>https://www.maxar.com/</a></li>
       </ul>
 
 


### PR DESCRIPTION
## Summary

Updates the Image Layers docs (and the mirrored in-app Help Docs) to point at Planet's open disaster data instead of the PlanetScope and SkySat developer doc pages.

## Changes

- **`docs/usage/image-layers.md`**
  - Replace the `Planet Scope` and `Planet Skysat` developer doc links with a single **Planet Disaster Data** link (<https://source.coop/planet/disasterdata>), listed first in the Sources list.
  - Note now explains that `black-river_visual_mosaic_cog.tif` is a mosaic of all the individual visual assets in [Planet's Hurricane Melissa 2025 Black River disaster data](https://source.coop/planet/disasterdata/hurricane-melissa-2025/post-event/black-river).
- **`ui/src/Components/HelpDocs/HelpDocsImageLayers.jsx`** — same Sources change, kept in sync per the source-of-truth note.

Vantor/Maxar entries were left unchanged as they were out of scope.