### PR TITLE
fix: metric-correct footprint buffering for geographic (EPSG:4326) prediction CRS

### DIFF
--- a/docker/training/code/merge_with_building_footprints.py
+++ b/docker/training/code/merge_with_building_footprints.py
@@ -9,10 +9,82 @@ import os
 import fiona
 import fiona.transform
 import numpy as np
+import pyproj
 import rasterio
 import rasterio.mask
 import shapely.geometry
 from tqdm import tqdm
+
+
+def metric_crs_for(predictions_crs: str, raster_bounds) -> str:
+    """Return a metre-based CRS suitable for buffering in ``predictions_crs``.
+
+    Buffer distances in this script are expressed in **metres**, but
+    ``shapely.buffer`` operates in the geometry's own coordinate units. So
+    the CRS we buffer in matters:
+
+    * If ``predictions_crs`` is *projected* (UTM / Web Mercator, units of
+      metres) we return it unchanged and buffering happens directly.
+    * If ``predictions_crs`` is *geographic* (e.g. EPSG:4326, units of
+      degrees) buffering by a metre value would be nonsensical
+      (``buffer(10)`` would be ~10 degrees ~= 1100 km), so we estimate a
+      local UTM CRS from the raster's centre and buffer in that instead.
+
+    This mirrors the ``estimate_utm_crs`` convention used elsewhere in the
+    codebase (see ``hastegeo.core.utils.assessment._building_areas_m2``).
+
+    ``raster_bounds`` is a ``(left, bottom, right, top)`` tuple expressed in
+    ``predictions_crs``.
+    """
+    crs = pyproj.CRS.from_user_input(predictions_crs)
+    if not crs.is_geographic:
+        # Already metric — buffer distances in metres are correct as-is.
+        return predictions_crs
+
+    left, bottom, right, top = raster_bounds
+    center_lon = (left + right) / 2.0
+    center_lat = (bottom + top) / 2.0
+    # Standard UTM zone from the AOI centre. Northern hemisphere zones are
+    # EPSG:326xx, southern EPSG:327xx.
+    zone = int((center_lon + 180) / 6) + 1
+    epsg = (32600 if center_lat >= 0 else 32700) + zone
+    return f"EPSG:{epsg}"
+
+
+def buffered_shape(
+    building_geom,
+    predictions_crs: str,
+    metric_crs: str,
+    buffer_m: float,
+) -> "shapely.geometry.base.BaseGeometry":
+    """Buffer ``building_geom`` by ``buffer_m`` metres, in ``predictions_crs``.
+
+    ``building_geom`` is a GeoJSON-like mapping already expressed in
+    ``predictions_crs``. The returned shapely geometry is also in
+    ``predictions_crs`` so it can be handed straight to
+    ``rasterio.mask.mask`` (which requires the mask geometry to share the
+    raster's CRS).
+
+    When ``metric_crs`` differs from ``predictions_crs`` (i.e. the raster is
+    geographic and ``buffer_m`` is non-zero) we round-trip the geometry
+    through the metric CRS: project to metres, buffer, then project back to
+    ``predictions_crs``. This is what makes the buffer distance metrically
+    correct regardless of the raster's CRS.
+    """
+    # ``buffer(0)`` is unit-independent (it just cleans the geometry), and
+    # for a projected raster ``metric_crs`` equals ``predictions_crs``. In
+    # both cases we can buffer directly without a reprojection round-trip.
+    if buffer_m == 0 or metric_crs == predictions_crs:
+        return shapely.geometry.shape(building_geom).buffer(buffer_m)
+
+    geom_metric = fiona.transform.transform_geom(
+        predictions_crs, metric_crs, building_geom
+    )
+    buffered = shapely.geometry.shape(geom_metric).buffer(buffer_m)
+    buffered_back = fiona.transform.transform_geom(
+        metric_crs, predictions_crs, shapely.geometry.mapping(buffered)
+    )
+    return shapely.geometry.shape(buffered_back)
 
 
 def set_up_parser() -> argparse.ArgumentParser:
@@ -68,13 +140,20 @@ def main(args):
     unknown_val_per_geom = []
     print(f"Reading predictions from {args.predictions_fn}")
     with rasterio.open(args.predictions_fn) as f:
+        # Buffer distances below are in METRES. shapely buffers in the
+        # geometry's own units, so for a geographic prediction CRS
+        # (e.g. EPSG:4326, degrees) we buffer in an estimated metric UTM
+        # CRS and transform back; for a projected CRS we buffer directly.
+        # Compute the metric CRS once here (not per geometry) — the loop
+        # below can run over many thousands of footprints.
+        metric_crs = metric_crs_for(predictions_crs, f.bounds)
         # Compute the fraction of damage per geometry and buffer size option
         for building_geom in tqdm(projected_building_geoms):
             skip_geom = False
             t_dmg_vals = []
             for buffer in [0, 10, 20]:
-                building_shape = shapely.geometry.shape(building_geom).buffer(
-                    buffer
+                building_shape = buffered_shape(
+                    building_geom, predictions_crs, metric_crs, buffer
                 )
                 try:
                     building_mask, transform = rasterio.mask.mask(
@@ -112,6 +191,9 @@ def main(args):
 
         # Compute the fraction of unknown (cloud covered) pixels per geometry
         for building_geom in tqdm(valid_building_geoms):
+            # No buffering here (buffer 0 == the geometry itself), so this
+            # masks the footprint directly in ``predictions_crs`` and needs
+            # no metric-CRS round-trip.
             building_shape = shapely.geometry.shape(building_geom)
 
             building_mask, transform = rasterio.mask.mask(

--- a/docker/training/code/test_merge_with_building_footprints.py
+++ b/docker/training/code/test_merge_with_building_footprints.py
@@ -1,0 +1,235 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Tests for ``merge_with_building_footprints.py``.
+
+Focus: the CRS-aware metric buffering used when merging damage
+predictions with building footprints. The regression these tests guard
+against is buffering a *geographic* (EPSG:4326, degrees) prediction
+raster by a metre distance directly, which balloons the footprint by
+tens of degrees and either crashes or yields nonsensical damage
+fractions.
+
+The test builds tiny synthetic fixtures with rasterio / geopandas (no
+hand-rolled raster or vector bytes) and drives the script's ``main``
+entrypoint plus its pure helpers.
+"""
+
+import argparse
+import os
+import sys
+import tempfile
+import unittest
+
+import fiona
+import geopandas as gpd
+import numpy as np
+import rasterio
+import shapely.geometry
+from rasterio.transform import from_origin
+
+# The script under test lives next to this file and is not installed as a
+# package, so make it importable by path.
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+if SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, SCRIPT_DIR)
+
+import merge_with_building_footprints as merge  # noqa: E402
+
+
+def _write_raster(path, arr, crs, transform):
+    """Write a single-band uint8 raster with rasterio."""
+    height, width = arr.shape
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=height,
+        width=width,
+        count=1,
+        dtype="uint8",
+        crs=crs,
+        transform=transform,
+        nodata=0,
+    ) as dst:
+        dst.write(arr, 1)
+
+
+def _damage_array():
+    """A 40x40 label array: class-2 ring around a class-3 damaged core.
+
+    The concentric layout means a *metrically correct* buffer picks up
+    progressively more class-2 pixels, so the damaged fraction strictly
+    decreases from 0 m -> 10 m -> 20 m. A degrees-based buffer instead
+    swallows the whole raster at both 10 and 20, collapsing those two
+    values to the same number -- which is exactly what the fix prevents.
+    """
+    arr = np.zeros((40, 40), dtype="uint8")
+    arr[15:26, 15:26] = 2  # surrounding (undamaged) pixels
+    arr[19:22, 19:22] = 3  # damaged core
+    return arr
+
+
+def _core_polygon(origin_x, origin_y, px, py):
+    """Polygon covering the 3x3 damaged core (rows/cols 19..21)."""
+    x0 = origin_x + 19 * px
+    x1 = origin_x + 22 * px
+    # ``py`` is the (positive) pixel height; rows increase downward.
+    y_top = origin_y - 19 * py
+    y_bot = origin_y - 22 * py
+    return shapely.geometry.box(x0, y_bot, x1, y_top)
+
+
+def _write_footprints(path, polygon, crs):
+    """Write a one-row footprints GeoPackage with geopandas."""
+    gdf = gpd.GeoDataFrame({"id": [0]}, geometry=[polygon], crs=crs)
+    gdf.to_file(path, driver="GPKG")
+
+
+def _read_output(path):
+    """Return the list of feature property dicts from an output GPKG."""
+    with fiona.open(path) as src:
+        return [dict(feat["properties"]) for feat in src]
+
+
+class MetricCrsForTest(unittest.TestCase):
+    """Unit tests for :func:`metric_crs_for`."""
+
+    def test_geographic_returns_utm(self):
+        # A point off the US west coast -> UTM zone 10N (EPSG:32610).
+        bounds = (-122.400, 37.698, -122.396, 37.702)
+        self.assertEqual(
+            merge.metric_crs_for("EPSG:4326", bounds), "EPSG:32610"
+        )
+
+    def test_geographic_southern_hemisphere_returns_326xx(self):
+        # Sydney-ish -> UTM zone 56S (EPSG:32756).
+        bounds = (151.20, -33.87, 151.22, -33.85)
+        self.assertEqual(
+            merge.metric_crs_for("EPSG:4326", bounds), "EPSG:32756"
+        )
+
+    def test_projected_returns_input_unchanged(self):
+        # Projected CRS units are already metres -> no round-trip needed.
+        bounds = (500000.0, 4170000.0, 500400.0, 4170400.0)
+        self.assertEqual(
+            merge.metric_crs_for("EPSG:32610", bounds), "EPSG:32610"
+        )
+
+
+class BufferedShapeTest(unittest.TestCase):
+    """Unit tests for :func:`buffered_shape`."""
+
+    def test_projected_matches_direct_shapely_buffer(self):
+        # When metric_crs == predictions_crs the helper must be a no-op
+        # wrapper around shapely.buffer -> zero behaviour change.
+        poly = shapely.geometry.box(0, 0, 10, 10)
+        geom = shapely.geometry.mapping(poly)
+        got = merge.buffered_shape(geom, "EPSG:32610", "EPSG:32610", 10)
+        expected = shapely.geometry.shape(geom).buffer(10)
+        self.assertTrue(got.equals(expected))
+
+    def test_geographic_buffer_is_metric(self):
+        # Buffer a ~10 m building by 20 m in EPSG:4326; the reprojected,
+        # buffered footprint should measure ~20 m of growth in UTM, not
+        # ~20 degrees.
+        poly = _core_polygon(-122.4000, 37.7020, 0.0001, 0.0001)
+        geom = shapely.geometry.mapping(poly)
+        metric = "EPSG:32610"
+        buffered = merge.buffered_shape(geom, "EPSG:4326", metric, 20)
+        # Reproject both to UTM and compare bounding-box growth.
+        base_m = gpd.GeoSeries([poly], crs="EPSG:4326").to_crs(metric)
+        buf_m = gpd.GeoSeries([buffered], crs="EPSG:4326").to_crs(metric)
+        b0 = base_m.total_bounds
+        b1 = buf_m.total_bounds
+        grow_left = b0[0] - b1[0]
+        grow_right = b1[2] - b0[2]
+        # ~20 m of growth per side (tolerate projection/rounding slack).
+        self.assertAlmostEqual(grow_left, 20.0, delta=3.0)
+        self.assertAlmostEqual(grow_right, 20.0, delta=3.0)
+
+    def test_geographic_buffer_zero_is_noop(self):
+        poly = _core_polygon(-122.4000, 37.7020, 0.0001, 0.0001)
+        geom = shapely.geometry.mapping(poly)
+        got = merge.buffered_shape(geom, "EPSG:4326", "EPSG:32610", 0)
+        expected = shapely.geometry.shape(geom).buffer(0)
+        self.assertTrue(got.equals(expected))
+
+
+class MainIntegrationTest(unittest.TestCase):
+    """End-to-end runs of :func:`main` for geographic and projected CRS."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def _run_main(self, predictions_fn, footprints_fn):
+        output_fn = os.path.join(self.tmp, "merged.gpkg")
+        args = argparse.Namespace(
+            footprints_fn=footprints_fn,
+            predictions_fn=predictions_fn,
+            output_fn=output_fn,
+            overwrite=True,
+        )
+        merge.main(args)
+        return output_fn
+
+    def test_geographic_epsg4326_does_not_crash_and_computes(self):
+        # --- Fixture: EPSG:4326 raster + overlapping footprint. ---
+        arr = _damage_array()
+        west, north, px = -122.4000, 37.7020, 0.0001
+        transform = from_origin(west, north, px, px)
+        pred_fn = os.path.join(self.tmp, "pred_4326.tif")
+        _write_raster(pred_fn, arr, "EPSG:4326", transform)
+
+        poly = _core_polygon(west, north, px, px)
+        fp_fn = os.path.join(self.tmp, "fp_4326.gpkg")
+        _write_footprints(fp_fn, poly, "EPSG:4326")
+
+        # (a) does not crash
+        output_fn = self._run_main(pred_fn, fp_fn)
+
+        # (b) output produced with the one valid building geom
+        self.assertTrue(os.path.exists(output_fn))
+        rows = _read_output(output_fn)
+        self.assertEqual(len(rows), 1)
+
+        # (c) buffered damage percentages computed and metrically sane:
+        # 0 m fully damaged, then strictly decreasing as the metric buffer
+        # pulls in surrounding class-2 pixels. Under the (buggy) degrees
+        # buffer, 10 m and 20 m collapse to the same value.
+        props = rows[0]
+        d0 = props["damage_pct_0m"]
+        d10 = props["damage_pct_10m"]
+        d20 = props["damage_pct_20m"]
+        for val in (d0, d10, d20):
+            self.assertTrue(np.isfinite(val))
+        self.assertAlmostEqual(d0, 1.0, places=6)
+        self.assertLess(d10, d0)
+        self.assertLess(d20, d10)
+        self.assertIn("unknown_pct", props)
+
+    def test_projected_utm_unchanged(self):
+        # --- Fixture: EPSG:32610 (metre) raster + footprint. ---
+        arr = _damage_array()
+        origin_x, origin_y, px = 500000.0, 4170000.0, 10.0
+        transform = from_origin(origin_x, origin_y, px, px)
+        pred_fn = os.path.join(self.tmp, "pred_utm.tif")
+        _write_raster(pred_fn, arr, "EPSG:32610", transform)
+
+        poly = _core_polygon(origin_x, origin_y, px, px)
+        fp_fn = os.path.join(self.tmp, "fp_utm.gpkg")
+        _write_footprints(fp_fn, poly, "EPSG:32610")
+
+        output_fn = self._run_main(pred_fn, fp_fn)
+
+        self.assertTrue(os.path.exists(output_fn))
+        rows = _read_output(output_fn)
+        self.assertEqual(len(rows), 1)
+        props = rows[0]
+        self.assertAlmostEqual(props["damage_pct_0m"], 1.0, places=6)
+        self.assertLess(props["damage_pct_10m"], props["damage_pct_0m"])
+        self.assertLess(props["damage_pct_20m"], props["damage_pct_10m"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Creating an Image Layer from a COG whose CRS is **EPSG:4326 (geographic, degrees)** causes the **inference** step to crash during "merge results with building footprints."

## Root cause

`docker/training/code/merge_with_building_footprints.py` transforms each building footprint into the **prediction raster's CRS**, then buffers it by `[0, 10, 20]` — distances intended as **metres** — via `shapely...buffer(buffer)`. `shapely` buffers in the geometry's own units:

- **Projected CRS (UTM / Web Mercator, metres):** `buffer(10)` = 10 m ✅
- **Geographic CRS (EPSG:4326, degrees):** `buffer(10)` = 10 **degrees** (~1100 km), `buffer(20)` ~2200 km ❌

The ballooned geometry no longer overlaps the raster, so `rasterio.mask.mask` raises `ValueError` for effectively every footprint → all geoms skipped → `damage_vals_per_geom` empty → the script crashes on `damage_vals_per_geom[:, 0]`. Inference breaks for any EPSG:4326 layer.

## Fix

Buffer in a metric CRS regardless of the raster's CRS, while keeping the mask geometry in the raster's CRS (as `rasterio.mask` requires):

- **`metric_crs_for(predictions_crs, raster_bounds)`** — returns `predictions_crs` unchanged when it's already projected (**zero behavior change for existing layers**); when geographic, estimates a local UTM CRS from the raster centre. Mirrors the `estimate_utm_crs` convention in `hastegeo.core.utils.assessment._building_areas_m2`.
- **`buffered_shape(building_geom, predictions_crs, metric_crs, buffer_m)`** — for `buffer 0` or a projected raster, buffers directly (preserves the current `.buffer(0)` geometry-cleaning); for a geographic raster with a non-zero buffer, round-trips `predictions_crs → metric CRS → buffer(metres) → predictions_crs`.
- The metric CRS is computed **once** outside the per-footprint loop (the loop can run over many thousands of footprints).
- The unknown/cloud pass buffers by nothing, so it's unaffected (comment added).

## Tests

New `docker/training/code/test_merge_with_building_footprints.py` (8 tests, `unittest`, rasterio/geopandas fixtures — no hand-rolled bytes):

- `metric_crs_for`: geographic → UTM 10N / 56S; projected → unchanged.
- `buffered_shape`: projected path equals direct `shapely.buffer`; a 20 m buffer in EPSG:4326 grows ~20 m (not ~20°) measured in UTM; `buffer(0)` is a no-op.
- End-to-end `main()` on a synthetic **EPSG:4326** raster (concentric class-2 ring around a class-3 damaged core) + overlapping footprint: does not crash, produces the output GPKG with the valid geom, and yields a **strictly decreasing** damaged fraction across 0/10/20 m (a degrees buffer collapses 10 m and 20 m to the same value). Plus a **EPSG:32610** case proving projected behavior is unchanged.

**Test run (independently verified):** `Ran 8 tests ... OK`. Repo pre-commit hooks (black/isort/flake8/detect-secrets) all pass.

## Deploy note

This script is baked into the **training image** and spawned via `docker run` by the queue worker (`docker/training/code/run_workflow.py`). The **`training_image` must be rebuilt** for the fix to take effect. No `hastegeo`/`imageryprep_image` change is required.
