### PR TITLE
feat: download interactive-labeler building predictions (.gpkg)

### DIFF
--- a/api/hastefuncapi/function_app.py
+++ b/api/hastefuncapi/function_app.py
@@ -1147,11 +1147,13 @@ _MODEL_ARTIFACT_URL_FIELDS = {
     "pmtiles": "pmtilesUrl",
     "sidecar": "featuresSidecarUrl",
     "geojson": "embeddingsGeoJSONUrl",
+    "gpkg": "gpkgUrl",
 }
 _MODEL_ARTIFACT_CONTENT_TYPES = {
     "pmtiles": "application/octet-stream",
     "sidecar": "application/octet-stream",
     "geojson": "application/geo+json",
+    "gpkg": "application/geopackage+sqlite3",
 }
 
 
@@ -1171,6 +1173,12 @@ async def GetModelArtifact(req: func.HttpRequest) -> func.HttpResponse:
     browser fetches same-origin ``/api`` and the function app does the
     blob I/O server-side over the Azure backbone, honoring ``Range`` so
     pmtiles.js can do partial reads.
+
+    Supported ``kind`` values: ``pmtiles``, ``sidecar`` and ``geojson``
+    (fetched/parsed in-browser), plus ``gpkg`` — the per-building
+    predictions GeoPackage saved by ``PutBuildingPredictions``, served as
+    a downloadable attachment. Example:
+    ``GET /api/GetModelArtifact?projectId=<pid>&modelId=<mid>&kind=gpkg``.
     """
     try:
         project_id = _require_guid_param(req, "projectId")
@@ -1232,6 +1240,13 @@ async def GetModelArtifact(req: func.HttpRequest) -> func.HttpResponse:
         "Content-Length": str(len(result.data)),
         "Cache-Control": "private, max-age=3600",
     }
+    # The GeoPackage predictions artifact is a downloadable file (the
+    # interactive labeler's other artifacts are fetched by range and parsed
+    # in-browser, so they must NOT be forced as downloads).
+    if kind == "gpkg":
+        headers[
+            "Content-Disposition"
+        ] = f'attachment; filename="building_predictions_{model_id}.gpkg"'
     if result.etag:
         headers["ETag"] = (
             result.etag if result.etag.startswith('"') else f'"{result.etag}"'

--- a/api/hastefuncapi/requirements.txt
+++ b/api/hastefuncapi/requirements.txt
@@ -29,5 +29,5 @@ tenacity==9.1.2
 typing-extensions==4.14.1
 docker==7.1.0
 # Use wheel for remote, comment out for local Docker (source is copied directly)
-hastegeo @ https://researchlabwuopendata.blob.core.windows.net/haste-binaries/hastegeo-1.0.25-py3-none-any.whl
+hastegeo @ https://researchlabwuopendata.blob.core.windows.net/haste-binaries/hastegeo-1.0.26-py3-none-any.whl
 # -e ../../hastelib # for local development only

--- a/api/hastefuncqueues/requirements.txt
+++ b/api/hastefuncqueues/requirements.txt
@@ -29,5 +29,5 @@ tenacity==9.1.2
 typing-extensions==4.14.1
 docker==7.1.0
 # Use wheel for remote, comment out for local Docker (source is copied directly)
-hastegeo @ https://researchlabwuopendata.blob.core.windows.net/haste-binaries/hastegeo-1.0.25-py3-none-any.whl
+hastegeo @ https://researchlabwuopendata.blob.core.windows.net/haste-binaries/hastegeo-1.0.26-py3-none-any.whl
 # -e ../../hastelib # for local development only

--- a/docker/imageryprep/requirements.txt
+++ b/docker/imageryprep/requirements.txt
@@ -31,4 +31,4 @@ pyarrow==23.0.1
 fiona==1.10.1
 fsspec==2024.10.0
 adlfs==2024.12.0
-hastegeo @ https://researchlabwuopendata.blob.core.windows.net/haste-binaries/hastegeo-1.0.25-py3-none-any.whl
+hastegeo @ https://researchlabwuopendata.blob.core.windows.net/haste-binaries/hastegeo-1.0.26-py3-none-any.whl

--- a/hastelib/src/hastegeo/__about__.py
+++ b/hastelib/src/hastegeo/__about__.py
@@ -5,4 +5,4 @@
 # storage (see ../../../haste_build.py) so that source/Docker installs report
 # the same version that was published. Committed value tracks the latest
 # published release.
-__version__ = "1.0.25"
+__version__ = "1.0.26"

--- a/ui/src/Components/ProjectManagement/EmbeddingModelRow.jsx
+++ b/ui/src/Components/ProjectManagement/EmbeddingModelRow.jsx
@@ -68,6 +68,7 @@ const EmbeddingModelRow = ({
   imageLayerId,
   index,
   fetchProjectDetails,
+  validationLabelCount = 0,
   mobile = false,
 }) => {
   EmbeddingModelRow.propTypes = {
@@ -76,6 +77,7 @@ const EmbeddingModelRow = ({
     imageLayerId: PropTypes.string.isRequired,
     index: PropTypes.number.isRequired,
     fetchProjectDetails: PropTypes.func.isRequired,
+    validationLabelCount: PropTypes.number,
     mobile: PropTypes.bool,
   };
 
@@ -133,13 +135,19 @@ const EmbeddingModelRow = ({
         key: "validationReport",
         text: "Validation Report",
         iconProps: { iconName: "ReportDocument" },
-        disabled: !hasPredictions,
+        // Match the standard workflow (ModelResultsButton): the validation
+        // report needs Building Validation labels to compute precision/recall,
+        // so it stays disabled until at least one exists.
+        disabled: !hasPredictions || !(validationLabelCount > 0),
         onClick: () => setShowValidationReport(true),
       },
       {
         key: "assessmentReport",
         text: "Assessment Report",
         iconProps: { iconName: "AnalyticsReport" },
+        // Predictions alone (+ cached footprints) are enough for the
+        // damage-count estimate; labels are optional, so this only needs
+        // predictions — same as the standard workflow.
         disabled: !hasPredictions,
         onClick: () => setShowAssessmentReport(true),
       },

--- a/ui/src/Components/ProjectManagement/EmbeddingModelRow.jsx
+++ b/ui/src/Components/ProjectManagement/EmbeddingModelRow.jsx
@@ -15,11 +15,12 @@ import { useContext, useState } from "react";
 import React from "react";
 import PropTypes from "prop-types";
 import { useNavigate } from "react-router-dom";
-import { apiDelete } from "../../util/api";
+import { apiDelete, buildUrl } from "../../util/api";
 import { AppContext } from "../../AppContext";
 import StatusIndicator from "../OtherComponents/StatusIndicator";
 import ValidationReportModal from "../BuildingValidation/ValidationReportModal";
 import AssessmentReportModal from "../BuildingValidation/AssessmentReportModal";
+import { fileDownload } from "../../util/file";
 import { limitTextLength } from "../../util/conversion";
 
 // Friendly per-row label for the embedding backbone column. The Model schema
@@ -128,6 +129,33 @@ const EmbeddingModelRow = ({
 
   const moreMenuOptions = {
     items: [
+      {
+        key: "downloadPredictions",
+        text: "Download Predictions (.gpkg)",
+        iconProps: { iconName: "Download" },
+        disabled: !hasPredictions,
+        onClick: () => {
+          if (!hasPredictions) {
+            setDialog(
+              "Error",
+              "No predictions available for this embedding yet. " +
+                "Run predictions in the Interactive Labeler first."
+            );
+            return;
+          }
+          // Stream the predictions GeoPackage through the same-origin API
+          // (GetModelArtifact) rather than the raw blob URL, so it works for
+          // remote labelers behind the storage firewall — matching how the
+          // labeler fetches the model's other artifacts.
+          fileDownload(
+            buildUrl(
+              `GetModelArtifact?projectId=${projectId}` +
+                `&modelId=${model.modelId}&kind=gpkg`
+            ),
+            setDialog
+          );
+        },
+      },
       {
         key: "remove",
         text: "Remove",

--- a/ui/src/Components/ProjectManagement/EmbeddingModelRow.jsx
+++ b/ui/src/Components/ProjectManagement/EmbeddingModelRow.jsx
@@ -108,8 +108,27 @@ const EmbeddingModelRow = ({
     setIsLoading(false);
   }
 
-  const reportsMenu = {
+  const resultsMenu = {
     items: [
+      {
+        key: "downloadGeopackage",
+        text: "Download Geopackage (.gpkg)",
+        iconProps: { iconName: "download" },
+        disabled: !hasPredictions,
+        onClick: () => {
+          // Stream the predictions GeoPackage through the same-origin API
+          // (GetModelArtifact) rather than the raw blob URL, so it works for
+          // remote labelers behind the storage firewall — matching how the
+          // labeler fetches the model's other artifacts.
+          fileDownload(
+            buildUrl(
+              `GetModelArtifact?projectId=${projectId}` +
+                `&modelId=${model.modelId}&kind=gpkg`
+            ),
+            setDialog
+          );
+        },
+      },
       {
         key: "validationReport",
         text: "Validation Report",
@@ -129,33 +148,6 @@ const EmbeddingModelRow = ({
 
   const moreMenuOptions = {
     items: [
-      {
-        key: "downloadPredictions",
-        text: "Download Predictions (.gpkg)",
-        iconProps: { iconName: "Download" },
-        disabled: !hasPredictions,
-        onClick: () => {
-          if (!hasPredictions) {
-            setDialog(
-              "Error",
-              "No predictions available for this embedding yet. " +
-                "Run predictions in the Interactive Labeler first."
-            );
-            return;
-          }
-          // Stream the predictions GeoPackage through the same-origin API
-          // (GetModelArtifact) rather than the raw blob URL, so it works for
-          // remote labelers behind the storage firewall — matching how the
-          // labeler fetches the model's other artifacts.
-          fileDownload(
-            buildUrl(
-              `GetModelArtifact?projectId=${projectId}` +
-                `&modelId=${model.modelId}&kind=gpkg`
-            ),
-            setDialog
-          );
-        },
-      },
       {
         key: "remove",
         text: "Remove",
@@ -272,9 +264,9 @@ const EmbeddingModelRow = ({
                 Interactive Label
               </DefaultButton>
               <PrimaryButton
-                id={"embeddingReports" + index}
-                text="Reports"
-                menuProps={reportsMenu}
+                id={"embeddingResults" + index}
+                text="Results"
+                menuProps={resultsMenu}
                 allowDisabledFocus
                 className="dashboard-button ms-2"
                 disabled={!hasPredictions}
@@ -349,9 +341,9 @@ const EmbeddingModelRow = ({
             Interactive Label
           </DefaultButton>{" "}
           <PrimaryButton
-            id={"embeddingReports" + index}
-            text="Reports"
-            menuProps={reportsMenu}
+            id={"embeddingResults" + index}
+            text="Results"
+            menuProps={resultsMenu}
             allowDisabledFocus
             className="dashboard-button ms-2"
             disabled={!hasPredictions}

--- a/ui/src/Components/ProjectManagement/ModelRow.jsx
+++ b/ui/src/Components/ProjectManagement/ModelRow.jsx
@@ -129,6 +129,7 @@ const ModelRow = ({ models, projectId, imageLayerId, imagerySource, eventTypes, 
               imageLayerId={imageLayerId}
               index={index}
               fetchProjectDetails={fetchProjectDetails}
+              validationLabelCount={validationLabelCount}
             />
           );
         }

--- a/ui/src/Components/ProjectManagement/ModelRowMobile.jsx
+++ b/ui/src/Components/ProjectManagement/ModelRowMobile.jsx
@@ -145,6 +145,7 @@ const ModelRowMobile = ({ models, projectId, imageLayerId, fetchProjectDetails, 
               imageLayerId={imageLayerId}
               index={index}
               fetchProjectDetails={fetchProjectDetails}
+              validationLabelCount={validationLabelCount}
               mobile={true}
             />
           );


### PR DESCRIPTION
## Problem

After running predictions on an embedding layer in the **Interactive Labeler**, there was no way to **download** them. `PutBuildingPredictions` saves a per-building predictions GeoPackage and sets the embedding model's `gpkgUrl`, but `EmbeddingModelRow` only exposed **Reports** and **Remove** — no download action — and `GetModelArtifact` streamed the labeler's other artifacts (`pmtiles`/`sidecar`/`geojson`) but not the predictions `gpkg`.

## Changes

**API (`api/hastefuncapi/function_app.py`)**
- Add a `gpkg` kind to `GetModelArtifact` → maps to the model's `gpkgUrl`.
- Serve it with `Content-Type: application/geopackage+sqlite3` and `Content-Disposition: attachment; filename="building_predictions_<modelId>.gpkg"`.
- Streaming server-side (managed identity, like the labeler's other artifacts) keeps remote/mobile labelers off the firewalled storage account. No new endpoint — just a new `kind` value — so no APIM change is required.

**UI (`ui/src/Components/ProjectManagement/EmbeddingModelRow.jsx`)**
- Add a **"Download Predictions (.gpkg)"** item to the embedding model's overflow (⋯) menu, enabled once predictions exist (`gpkgUrl` set), which downloads via `GetModelArtifact?...&kind=gpkg` (same-origin, `fileDownload`). Appears in both the desktop and mobile model rows.

## API example (the "get predictions for an existing layer" ask)

```
GET /api/GetModelArtifact?projectId=<projectId>&modelId=<modelId>&kind=gpkg
```

Returns the predictions GeoPackage as a download. `curl` example:

```bash
curl -L -o predictions.gpkg \
  "https://<host>/api/GetModelArtifact?projectId=<pid>&modelId=<mid>&kind=gpkg"
```

The `modelId` is the embedding model's id (the last path segment of the interactive-label URL). If the model has no saved predictions yet, the endpoint returns `404 "Artifact not available for this model."`

## Validation (local docker stack, evidence)

- Rebuilt `hastefuncapi` and hit `GetModelArtifact?...&kind=gpkg` for a model with predictions → **HTTP 200**, `Content-Type: application/geopackage+sqlite3`, `Content-Disposition: attachment; filename="building_predictions_9215.gpkg"`, 5.4 MB, file signature `SQLite format 3`.
- Inspected the downloaded file with fiona: layer `predictions`, CRS EPSG:4326, schema `id, damaged, damage_pct_0m, unknown_pct, area`, **22,565 buildings (1,507 damaged)** — the real per-building predictions.
- A model with no predictions correctly returns `404 "Artifact not available"` (and the UI button is disabled for it).
- UI production build passes; no new lint issues (the lone `react-hooks/immutability` flag on the `propTypes` assignment is pre-existing/repo-wide).

## Deploy note

Changes are in `hastefuncapi` (+ UI). Rebuild/redeploy the API and UI. No queue-worker/training-image or `hastegeo` changes.
