### PR TITLE
fix: prefill administrator role for local Docker login

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -242,11 +242,10 @@ browser. The SWA emulator presents a **mock-login portal** (`DEVELOPMENT_MODE=tr
 bypasses real Azure AD in the API, but the UI still runs the SWA emulator auth).
 **Report this URL to the user as the finish line.**
 
-> For Docker Compose, keep the SWA emulator's default roles. Enter any
-> **User ID** and **Username**, then click **Login**. The local UI image accepts
-> the emulator's `authenticated` role, and `DEVELOPMENT_MODE=true` auto-creates
-> the user as an `administrators` user. This behavior is limited to the local
-> Docker image and does not change production authorization.
+> For Docker Compose, the SWA mock-login form pre-fills **User's roles** with
+> `administrators`. Enter any **User ID** and **Username**, confirm that role is
+> present, then click **Login**. This behavior is limited to the local Docker
+> image and does not change production authorization.
 
 If any check fails, go to [§9 Troubleshooting](#9-troubleshooting), apply the
 fix, and re-run this section.
@@ -330,7 +329,7 @@ Match the failing gate to a fix, apply it, then **re-run the gate**.
 | Pull dies mid-layer with `EOF` / `TLS handshake timeout` | flaky/VPN'd connection to `mcr.microsoft.com` | Turn off VPN; retry — Docker resumes cached layers, so a loop of retries converges. Pre-pull the base: `docker pull --platform linux/amd64 mcr.microsoft.com/azure-functions/python:4-python3.11` |
 | `up -d` unexpectedly builds `haste-training` (CUDA/torch wheels) | `hastefuncqueues depends_on training_image` | Start runtime services with `--no-deps` (§4) |
 | `--gpus all` test fails on Linux | NVIDIA Container Toolkit missing | Install it (`docker/README.md` §3), `sudo systemctl restart docker` |
-| UI stuck in login loop (login page reloads; logs show `401.html`↔`/.auth/login/aad`) | stale `ui` image built before the Docker-only auth default was added | Rebuild and recreate only `ui`, then log in with the emulator's default roles (Gate 5) |
+| UI stuck in login loop (login page reloads; logs show `401.html`↔`/.auth/login/aad`) | stale `ui` image built before the Docker-only administrator default was added | Rebuild and recreate only `ui`, confirm **User's roles** includes `administrators`, then log in (Gate 5) |
 | UI blank / "Network Error" (Gate 5) | `HOST_IP` wrong, or nginx stale | `cat docker/.env`; `docker compose ... restart api-proxy` |
 | `/api/GetAdminSettings` refuses connection | `hastefuncapi` not up / Azurite not ready | `docker compose ... logs --tail=200 hastefuncapi`; restart it |
 | `/api/*` returns 404 after a recreate | nginx cached old upstream IP | `docker compose ... restart api-proxy` (Trap #2) |
@@ -358,7 +357,7 @@ Report success to the user only when **all** of these hold:
 - [ ] `docker/.env` written with correct `HOST_IP`, `DOCKER_GID`, and GPU flag.
 - [ ] `docker compose ps` shows all long-running services `Up` and `data-init` `Exited (0)`.
 - [ ] Gate 5 health checks all pass (Azurite, API, TiTiler, UI).
-- [ ] The UI loads at `http://<HOST_IP>:4280`, accepts the SWA emulator's default mock-login roles, and creates the local user as an administrator.
+- [ ] The UI loads at `http://<HOST_IP>:4280` and the SWA emulator mock-login pre-fills `administrators`.
 - [ ] You told the user the profile (`gpu`/`cpu`) and, if `cpu`, that
       training/inference will be slow or limited.
 - [ ] On Apple Silicon: you exported `DOCKER_DEFAULT_PLATFORM=linux/amd64`,

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -242,15 +242,11 @@ browser. The SWA emulator presents a **mock-login portal** (`DEVELOPMENT_MODE=tr
 bypasses real Azure AD in the API, but the UI still runs the SWA emulator auth).
 **Report this URL to the user as the finish line.**
 
-> **⚠️ You MUST supply a role at the mock-login form, or you get a redirect
-> loop.** Every route in `ui/public/staticwebapp.config.json` requires
-> `allowedRoles: ["administrators", "contributors"]`, and the SWA emulator only
-> grants `anonymous`/`authenticated` by default — so logging in without a role
-> just bounces you back to the login page (logs show `/401.html → 401` then
-> `/.auth/login/aad → 200`, repeating). On the emulator login form fill:
-> **User ID** = anything (e.g. `dev`), **Username** = anything, and
-> **User's roles** = **`administrators`** (or `administrators,contributors`),
-> then click **Login**. The app then loads.
+> For Docker Compose, keep the SWA emulator's default roles. Enter any
+> **User ID** and **Username**, then click **Login**. The local UI image accepts
+> the emulator's `authenticated` role, and `DEVELOPMENT_MODE=true` auto-creates
+> the user as an `administrators` user. This behavior is limited to the local
+> Docker image and does not change production authorization.
 
 If any check fails, go to [§9 Troubleshooting](#9-troubleshooting), apply the
 fix, and re-run this section.
@@ -334,7 +330,7 @@ Match the failing gate to a fix, apply it, then **re-run the gate**.
 | Pull dies mid-layer with `EOF` / `TLS handshake timeout` | flaky/VPN'd connection to `mcr.microsoft.com` | Turn off VPN; retry — Docker resumes cached layers, so a loop of retries converges. Pre-pull the base: `docker pull --platform linux/amd64 mcr.microsoft.com/azure-functions/python:4-python3.11` |
 | `up -d` unexpectedly builds `haste-training` (CUDA/torch wheels) | `hastefuncqueues depends_on training_image` | Start runtime services with `--no-deps` (§4) |
 | `--gpus all` test fails on Linux | NVIDIA Container Toolkit missing | Install it (`docker/README.md` §3), `sudo systemctl restart docker` |
-| UI stuck in login loop (login page reloads; logs show `401.html`↔`/.auth/login/aad`) | mock-login granted no role; routes need `administrators`/`contributors` | On the SWA emulator login form set **User's roles** = `administrators`, then Login (Gate 5) |
+| UI stuck in login loop (login page reloads; logs show `401.html`↔`/.auth/login/aad`) | stale `ui` image built before the Docker-only auth default was added | Rebuild and recreate only `ui`, then log in with the emulator's default roles (Gate 5) |
 | UI blank / "Network Error" (Gate 5) | `HOST_IP` wrong, or nginx stale | `cat docker/.env`; `docker compose ... restart api-proxy` |
 | `/api/GetAdminSettings` refuses connection | `hastefuncapi` not up / Azurite not ready | `docker compose ... logs --tail=200 hastefuncapi`; restart it |
 | `/api/*` returns 404 after a recreate | nginx cached old upstream IP | `docker compose ... restart api-proxy` (Trap #2) |
@@ -362,7 +358,7 @@ Report success to the user only when **all** of these hold:
 - [ ] `docker/.env` written with correct `HOST_IP`, `DOCKER_GID`, and GPU flag.
 - [ ] `docker compose ps` shows all long-running services `Up` and `data-init` `Exited (0)`.
 - [ ] Gate 5 health checks all pass (Azurite, API, TiTiler, UI).
-- [ ] The UI loads at `http://<HOST_IP>:4280` and you can complete the SWA emulator mock-login with role `administrators` (or `contributors`).
+- [ ] The UI loads at `http://<HOST_IP>:4280`, accepts the SWA emulator's default mock-login roles, and creates the local user as an administrator.
 - [ ] You told the user the profile (`gpu`/`cpu`) and, if `cpu`, that
       training/inference will be slow or limited.
 - [ ] On Apple Silicon: you exported `DOCKER_DEFAULT_PLATFORM=linux/amd64`,

--- a/docker/README.md
+++ b/docker/README.md
@@ -573,10 +573,9 @@ Open a browser and navigate to:
 http://<HOST_IP>:4280
 ```
 
-> The SWA mock-login portal still appears for the UI. Keep its default roles,
-> enter any user ID and username, and select **Login**. The Docker-only UI
-> configuration accepts the default `authenticated` role, and
-> `DEVELOPMENT_MODE=true` auto-creates that local user as an administrator.
+> The SWA mock-login portal still appears for the UI. The Docker image pre-fills
+> **User's roles** with `administrators`; enter any user ID and username,
+> confirm the role is present, and select **Login**.
 
 ### Creating a Project
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -573,8 +573,10 @@ Open a browser and navigate to:
 http://<HOST_IP>:4280
 ```
 
-> In `DEVELOPMENT_MODE=true`, authentication is bypassed. You'll be logged in as an
-> auto-created development user.
+> The SWA mock-login portal still appears for the UI. Keep its default roles,
+> enter any user ID and username, and select **Login**. The Docker-only UI
+> configuration accepts the default `authenticated` role, and
+> `DEVELOPMENT_MODE=true` auto-creates that local user as an administrator.
 
 ### Creating a Project
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -140,6 +140,11 @@ production setting), Functions are key-protected (the postdeploy hook injects th
 host key into the APIM backends) and unknown users are rejected until an admin
 adds them.
 
+The Docker Compose UI image also accepts the SWA emulator's default
+`authenticated` role. This lets the development-mode API create the local user
+as an administrator without requiring a manual role entry. The source
+`staticwebapp.config.json` used for production is unchanged.
+
 ## First-admin bootstrap
 
 Production uses `DEVELOPMENT_MODE=false`, so users are managed explicitly and are

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -140,10 +140,9 @@ production setting), Functions are key-protected (the postdeploy hook injects th
 host key into the APIM backends) and unknown users are rejected until an admin
 adds them.
 
-The Docker Compose UI image also accepts the SWA emulator's default
-`authenticated` role. This lets the development-mode API create the local user
-as an administrator without requiring a manual role entry. The source
-`staticwebapp.config.json` used for production is unchanged.
+The Docker Compose UI image pre-fills `administrators` in the SWA emulator's
+mock-login form. The source `staticwebapp.config.json` used for production is
+unchanged.
 
 ## First-admin bootstrap
 

--- a/docs/setup/local-dev.md
+++ b/docs/setup/local-dev.md
@@ -72,8 +72,9 @@ Once running:
 - **Azurite blob** — `http://<HOST_IP>:10000`
 
 ```{important}
-At the SWA mock-login form, set **User's roles** to `administrators`, or the app bounces
-you back to the login page.
+For Docker Compose, keep the SWA mock-login form's default roles. Enter a user
+ID and username, then select **Login**. The local API automatically creates the
+user as an administrator.
 ```
 
 ```{tip}

--- a/docs/setup/local-dev.md
+++ b/docs/setup/local-dev.md
@@ -72,9 +72,9 @@ Once running:
 - **Azurite blob** — `http://<HOST_IP>:10000`
 
 ```{important}
-For Docker Compose, keep the SWA mock-login form's default roles. Enter a user
-ID and username, then select **Login**. The local API automatically creates the
-user as an administrator.
+For Docker Compose, the SWA mock-login form pre-fills **User's roles** with
+`administrators`. Enter a user ID and username, confirm the role is present,
+then select **Login**.
 ```
 
 ```{tip}

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -17,6 +17,10 @@ RUN npm install
 # Copy application files
 COPY --chown=nonroot:nonroot . .
 
+# The emulator grants "authenticated" by default; development mode then
+# auto-provisions that local user as an administrator.
+RUN node -e "const fs=require('node:fs');const p='public/staticwebapp.config.json';const c=JSON.parse(fs.readFileSync(p,'utf8'));const r=c.routes.find(({route})=>route==='/*');if(!r||!Array.isArray(r.allowedRoles)||r.allowedRoles.join(',')!=='administrators,contributors')throw new Error('Unexpected SWA roles');r.allowedRoles.unshift('authenticated');fs.writeFileSync(p,JSON.stringify(c,null,2)+'\n');"
+
 # Copy the Docker-specific environment file
 COPY --chown=nonroot:nonroot .env.docker .env
 

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -3,6 +3,9 @@ FROM mcr.microsoft.com/azurelinux/base/nodejs:24
 # Install global CLI as root first
 RUN npm install -g @azure/static-web-apps-cli
 
+# Prefill the administrator role in the Docker-only SWA mock-login portal.
+RUN node -e "const fs=require('node:fs');const path=require('node:path');const {execFileSync}=require('node:child_process');const root=execFileSync('npm',['root','-g'],{encoding:'utf8'}).trim();const p=path.join(root,'@azure','static-web-apps-cli','dist','public','auth.html');let s=fs.readFileSync(p,'utf8');const defaults='const defaultRoles = [\"anonymous\", \"authenticated\"];';const cached='input.val(userRoles.join(\"\\\\n\"));';if(!s.includes(defaults)||!s.includes(cached))throw new Error('Unexpected SWA auth portal');s=s.replace(defaults,'const defaultRoles = [\"anonymous\", \"authenticated\", \"administrators\"];').replace(cached,'input.val([...new Set([...userRoles, ...settings.defaultRoles])].join(\"\\\\n\"));\\n                input.saveToLocalStorage();');fs.writeFileSync(p,s);"
+
 # Set up workdir and ownership *before* switching users
 WORKDIR /app
 RUN chown nonroot:nonroot /app
@@ -16,10 +19,6 @@ RUN npm install
 
 # Copy application files
 COPY --chown=nonroot:nonroot . .
-
-# The emulator grants "authenticated" by default; development mode then
-# auto-provisions that local user as an administrator.
-RUN node -e "const fs=require('node:fs');const p='public/staticwebapp.config.json';const c=JSON.parse(fs.readFileSync(p,'utf8'));const r=c.routes.find(({route})=>route==='/*');if(!r||!Array.isArray(r.allowedRoles)||r.allowedRoles.join(',')!=='administrators,contributors')throw new Error('Unexpected SWA roles');r.allowedRoles.unshift('authenticated');fs.writeFileSync(p,JSON.stringify(c,null,2)+'\n');"
 
 # Copy the Docker-specific environment file
 COPY --chown=nonroot:nonroot .env.docker .env


### PR DESCRIPTION
## Summary

Prefill the `administrators` role in the Azure Static Web Apps mock-login portal used by Docker Compose. Local users can now enter a user ID and username and log in without knowing that they must manually add the HASTE administrator role.

The change is isolated to the SWA CLI installed inside the local UI Docker image. Production authorization and the source `staticwebapp.config.json` remain unchanged.

## Changes

- Patch the Docker image's SWA mock-login portal to include `administrators` in its default roles.
- Merge the default roles into cached emulator profiles so existing local browser sessions also receive `administrators`.
- Fail the image build if the expected SWA portal structure changes instead of silently losing the default.
- Update the quickstart, Docker, local-development, and configuration documentation to describe the new login flow.

## Testing

- [x] Built the UI Docker image locally.
- [x] Verified the served SWA login page pre-fills `anonymous`, `authenticated`, and `administrators`.
- [x] Verified a browser profile that had cached the old role list receives `administrators`.
- [x] Completed a mock login through the isolated UI container.
- [x] `cd ui && npm run build`
- [x] Formal pre-landing review completed with no findings.
- [ ] `cd ui && npm run lint` is blocked by the repository's existing ESLint 9 configuration mismatch (`eslint.config.js` is not present).

## Review Notes

The Docker build performs a guarded replacement against the installed SWA CLI asset. If a future SWA CLI release changes that asset, the build fails with `Unexpected SWA auth portal` so the local authentication behavior cannot regress silently.
