### PR TITLE
fix(open-data-catalog): handle nested Planet STAC layout and collecti…

### DIFF
--- a/ui/src/Components/OpenDataCatalog/openDataCatalog.js
+++ b/ui/src/Components/OpenDataCatalog/openDataCatalog.js
@@ -402,15 +402,29 @@ function planetSourceTypeKey(item, collection) {
     : SOURCE_TYPE_KEYS.planet;
 }
 
-function normalizePlanetItem({ item, itemUrl, collection, aboutUrl, eventDate }) {
+function normalizePlanetItem({
+  item,
+  itemUrl,
+  collection,
+  collectionUrl,
+  aboutUrl,
+  eventDate,
+  inheritedPhase,
+}) {
   const props = item.properties || {};
   const visual = pickVisualAsset(item.assets);
   const cogUrl = visual ? absUrl(visual.href, itemUrl) : null;
+  // Prefer a per-item thumbnail; otherwise fall back to the collection's
+  // shared thumbnail. The collection asset's href is relative to the
+  // collection document, not the item — resolve it against collectionUrl
+  // (some events, e.g. Gironde, ship no per-item thumbnail, so this fallback
+  // is the only list preview they have).
   const thumbUrl =
     assetHref(item.assets?.thumbnail, itemUrl) ||
-    assetHref(collection?.assets?.thumbnail, itemUrl);
+    assetHref(collection?.assets?.thumbnail, collectionUrl || itemUrl);
   const phase =
     planetPhaseFromCollectionId(item.collection || collection?.id) ||
+    inheritedPhase ||
     resolvePhase(null, props.datetime, eventDate);
   return {
     id: item.id,
@@ -463,8 +477,14 @@ function normalizePlanetMosaic({ collection, collectionUrl, asset }) {
   };
 }
 
-async function fetchPlanetCollectionScenes({ collectionDoc, collectionUrl, aboutUrl, eventDate }) {
-  const phase = planetPhaseFromCollectionId(collectionDoc.id);
+async function fetchPlanetCollectionScenes({
+  collectionDoc,
+  collectionUrl,
+  aboutUrl,
+  eventDate,
+  inheritedPhase,
+}) {
+  const phase = planetPhaseFromCollectionId(collectionDoc.id) || inheritedPhase;
   const mosaic = phase === "pre" ? collectionDoc.assets?.mosaic : null;
   if (mosaic) {
     return [
@@ -485,8 +505,10 @@ async function fetchPlanetCollectionScenes({ collectionDoc, collectionUrl, about
           item: doc,
           itemUrl: url,
           collection: collectionDoc,
+          collectionUrl,
           aboutUrl,
           eventDate,
+          inheritedPhase: phase,
         });
       } catch (err) {
         console.warn(`Skipping Planet STAC item ${itemUrl}: ${err.message}`);
@@ -497,20 +519,53 @@ async function fetchPlanetCollectionScenes({ collectionDoc, collectionUrl, about
   return items.filter(Boolean);
 }
 
+// Recursively descend Planet STAC `child` links until reaching nodes that
+// actually hold scenes (item links or a pre-event mosaic asset). Most events
+// expose collections directly under the root, but some nest an extra catalog
+// level (root → pre-/post-event catalog → dated collections → items); without
+// this walk those events surface as "no imagery available". The pre/post
+// `phase` is carried down from whichever ancestor declares it (e.g. the
+// intermediate "post-event" catalog), since the leaf collection ids
+// ("post-event-2026-07-29") don't match on their own.
+const PLANET_MAX_DEPTH = 5;
+
+async function collectPlanetCollections(doc, url, aboutUrl, inheritedPhase, depth = 0) {
+  const phase = planetPhaseFromCollectionId(doc.id) || inheritedPhase;
+  const about = stacLink(doc, "about", url) || aboutUrl;
+  const hasItems = stacLinks(doc, "item").length > 0;
+  const hasMosaic = phase === "pre" && !!doc.assets?.mosaic;
+  if (hasItems || hasMosaic) {
+    return [{ doc, url, aboutUrl: about, phase }];
+  }
+  if (depth >= PLANET_MAX_DEPTH) return [];
+  const childLinks = stacLinks(doc, "child");
+  const nested = await Promise.all(
+    childLinks.map(async (link) => {
+      const childUrl = absUrl(link.href, url);
+      try {
+        const { doc: childDoc, url: resolvedUrl } = await fetchJsonRetry(childUrl);
+        return collectPlanetCollections(childDoc, resolvedUrl, about, phase, depth + 1);
+      } catch (err) {
+        console.warn(`Skipping Planet STAC catalog ${childUrl}: ${err.message}`);
+        return [];
+      }
+    })
+  );
+  return nested.flat();
+}
+
 async function fetchPlanetScenes(src) {
   const { doc: root, url: rootUrl } = await fetchJsonRetry(src.catalogUrl);
-  const childLinks = stacLinks(root, "child");
-  const collections = await Promise.all(
-    childLinks.map((link) => fetchJsonRetry(absUrl(link.href, rootUrl)))
-  );
+  const rootAbout = stacLink(root, "about", rootUrl);
+  const collections = await collectPlanetCollections(root, rootUrl, rootAbout, null);
   const nested = await Promise.all(
-    collections.map(({ doc, url }) =>
+    collections.map(({ doc, url, aboutUrl, phase }) =>
       fetchPlanetCollectionScenes({
         collectionDoc: doc,
         collectionUrl: url,
-        aboutUrl:
-          stacLink(doc, "about", url) || stacLink(root, "about", rootUrl),
+        aboutUrl,
         eventDate: src.date,
+        inheritedPhase: phase,
       })
     )
   );

--- a/ui/src/Components/OpenDataCatalog/openDataCatalog.js
+++ b/ui/src/Components/OpenDataCatalog/openDataCatalog.js
@@ -369,14 +369,14 @@ function normalizeVantorItem(item, eventDate) {
   };
 }
 
-async function fetchVantorScenes(src) {
-  const collection = await fetchJson(src.collectionUrl);
-  const eventDate = (collection["odp:event_date"] || "").slice(0, 10) || null;
-  const itemLinks = stacLinks(collection, "item");
+// Fetch + normalize the STAC items linked directly from a Vantor collection
+// document located at `baseUrl`.
+async function fetchVantorItems(doc, baseUrl, eventDate) {
+  const itemLinks = stacLinks(doc, "item");
   const scenes = await Promise.all(
     itemLinks.map(async (l) => {
       try {
-        const item = await fetchJson(absUrl(l.href, src.collectionUrl));
+        const item = await fetchJson(absUrl(l.href, baseUrl));
         return normalizeVantorItem(item, eventDate);
       } catch {
         return null;
@@ -384,6 +384,40 @@ async function fetchVantorScenes(src) {
     })
   );
   return scenes.filter(Boolean);
+}
+
+// Vantor events normally list every scene item directly under the event
+// collection. As a safety net for a future event that instead nests items
+// under child collections (as some Planet events do — see
+// collectPlanetCollections), descend child links *only when a collection
+// exposes no direct items*. Events that already list items flat — the current
+// norm, including ones that ALSO nest redundant pre/post children — keep their
+// existing behavior with no extra fetches and no duplicate scenes.
+const VANTOR_MAX_DEPTH = 5;
+
+async function collectVantorScenes(doc, baseUrl, eventDate, depth = 0) {
+  const direct = await fetchVantorItems(doc, baseUrl, eventDate);
+  if (direct.length > 0 || depth >= VANTOR_MAX_DEPTH) return direct;
+  const childLinks = stacLinks(doc, "child");
+  const nested = await Promise.all(
+    childLinks.map(async (link) => {
+      const childUrl = absUrl(link.href, baseUrl);
+      try {
+        const childDoc = await fetchJson(childUrl);
+        return collectVantorScenes(childDoc, childUrl, eventDate, depth + 1);
+      } catch (err) {
+        console.warn(`Skipping Vantor STAC catalog ${childUrl}: ${err.message}`);
+        return [];
+      }
+    })
+  );
+  return nested.flat();
+}
+
+async function fetchVantorScenes(src) {
+  const collection = await fetchJson(src.collectionUrl);
+  const eventDate = (collection["odp:event_date"] || "").slice(0, 10) || null;
+  return collectVantorScenes(collection, src.collectionUrl, eventDate);
 }
 
 // ── Planet Open Data (Source Cooperative STAC) ──────────────────────────────


### PR DESCRIPTION
…on thumbnails

Two fixes for Planet Open Data events whose STAC tree nests an extra catalog level (root → pre-/post-event catalog → dated collections → items), e.g. Gironde Wildfire and Hurricane Melissa, which previously surfaced as "No imagery available for this event."

- fetchPlanetScenes now walks child catalogs recursively (collectPlanetCollections) until it reaches nodes that actually hold scenes, instead of assuming collections sit directly under the root. The pre/post phase is carried down from whichever ancestor declares it, since leaf collection ids (e.g. "post-event-2026-07-29") don't self-identify their phase.

- Resolve the collection-level thumbnail fallback against the collection URL rather than the item URL. Events with no per-item thumbnail asset (e.g. Gironde) previously produced a 404 thumbnail and an empty preview box in the scene list.

Verified against live catalogs: Gironde 0 -> 19 scenes (all with COG + thumbnail), Hurricane Melissa 0 -> 62 scenes; flat-layout events (Venezuela, Philippines) unchanged.

## Description

<!-- A clear and concise summary of the change and which issue it addresses. -->

Fixes # <!-- issue number, if applicable -->

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Infrastructure / CI change

## Checklist

- [X ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ X] My changes follow the project's coding standards (PEP 8 for Python, ESLint rules for JS/TS)
- [ ] I have added or updated tests that cover my changes
- [X] Python tests pass locally (`cd hastelib && hatch run test:pytest`) and the UI lints clean (`cd ui && npm run lint`)
- [ ] I have updated the relevant documentation (README, docs/, inline comments)
- [ ] I have added an entry to [CHANGELOG.md](../CHANGELOG.md) if this is a user-facing change

## Testing

<!-- Describe how you tested these changes. Include relevant commands, screenshots, or logs. -->

## Additional context

<!-- Any other context reviewers should know about. -->
