### PR TITLE
chore(deps): bump brace-expansion to 5.0.9 and override adm-zip to 0.6.0

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -3956,12 +3956,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -19,7 +19,7 @@
         "@fluentui/react-icons": "^2.0.333",
         "azure-maps-drawing-tools": "^1.0.4",
         "bootstrap": "^5.3.3",
-        "brace-expansion": "^5.0.6",
+        "brace-expansion": "^5.0.9",
         "chart.js": "^4.4.4",
         "clipper-lib": "^6.4.2",
         "cross-spawn": "^7.0.6",
@@ -4477,15 +4477,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -8926,9 +8926,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/ui/package.json
+++ b/ui/package.json
@@ -45,6 +45,7 @@
     "uuid": "^14.0.0"
   },
   "overrides": {
+    "adm-zip": "^0.6.0",
     "brace-expansion": "^5.0.9",
     "minimatch@3": {
       "brace-expansion": "^1.1.18"

--- a/ui/package.json
+++ b/ui/package.json
@@ -25,7 +25,7 @@
     "@fluentui/react-icons": "^2.0.333",
     "azure-maps-drawing-tools": "^1.0.4",
     "bootstrap": "^5.3.3",
-    "brace-expansion": "^5.0.6",
+    "brace-expansion": "^5.0.9",
     "chart.js": "^4.4.4",
     "clipper-lib": "^6.4.2",
     "cross-spawn": "^7.0.6",
@@ -45,7 +45,7 @@
     "uuid": "^14.0.0"
   },
   "overrides": {
-    "brace-expansion": "^5.0.6",
+    "brace-expansion": "^5.0.9",
     "minimatch@3": {
       "brace-expansion": "^1.1.18"
     },


### PR DESCRIPTION
## Summary

Closes the remaining resolvable Dependabot alerts on `ui/`. The `dependabot.yml` that was originally part of this PR has been split out into #132; this one is dependency bumps only.

Three logical changes, all in `ui/`.

### 1. `brace-expansion` 5.0.6 → 5.0.9

Resolves three open alerts:

| Alert | Severity | Advisory | First patched |
|-------|----------|----------|---------------|
| #58 | High | CVE-2026-13149 | 5.0.7 |
| #67 | High | CVE-2026-14257 | 5.0.8 |
| #68 | High | CVE-2026-69152 | 5.0.9 |

Three separate advisories against the same package, each patched in a different release. Only 5.0.9 clears all three — bumping to 5.0.7 or 5.0.8 leaves alerts open and invites a second and third PR.

`brace-expansion` is a direct production dependency in `ui/package.json`, pinned there alongside an `overrides` entry to force the hoisted copy to v5. Both were bumped so the pin and the override stay consistent.

**Node compatibility checked:** 5.0.9 narrows `engines.node` from `18 || 20 || >=22` to `20 || >=22`. Nothing in the repo targets Node 18 — `docker/ui/Dockerfile` is on 20.14 and `deploy-apps.yml` uses 24.

### 2. `adm-zip` 0.5.17 → 0.6.0, via `overrides`

Resolves alert #57 (high, CVE-2026-39244 / GHSA-xcpc-8h2w-3j85). `zipEntry.js` allocates a buffer from the uncompressed size declared in the ZIP central directory without bounds-checking it against the data actually present, so a ~120-byte crafted archive can force a 4GB allocation and crash the process. The allocation happens before CRC validation, so the payload can't be rejected early.

**This is the version conflict.** adm-zip reaches the tree only through `@azure/static-web-apps-cli`, which requires `^0.5.14` — a range that stops short of 0.6.0, and 0.6.0 is where the fix lives. Upgrading the CLI doesn't help: `static-web-apps-cli` still declares `^0.5.14` on `main` (2.0.10). And 0.5.18 is not a fix despite what the advisory prose implies — GitHub's vulnerable range is `< 0.6.0`. So the bump has to go through an `overrides` entry, forcing a semver-major on a transitive dependency.

Compatibility checked at the source level against the CLI's two adm-zip call sites, `src/core/func-core-tools.ts` (Functions Core Tools download) and `src/core/dataApiBuilder/dab.ts` (DAB binary download). Both only construct an `AdmZip` and call `extractAllTo()`. Neither of 0.6.0's two behaviour changes touches that path:

- `extractEntryTo(..., maintainEntryPath = false)` now preserves subdirectories instead of flattening — a different method, not called here.
- Extraction no longer fails when `utimes` can't set the modification time — strictly a relaxed failure mode.

`engines.node` widens from `>=12.0` to `>=14.0`, below every Node version this repo targets.

### 3. `nanoid` 3.3.16 → 3.3.18 in `ui/package-lock.json`

Not from an alert. The repo root was already fixed to 3.3.18 for CVE-2026-67213, but the `ui` lockfile still carried 3.3.16, which is below the fix line for the same advisory. Dependabot didn't raise a separate alert because the `ui` copy is dev-scoped (pulled in through postcss → vite). In range for postcss's `nanoid@^3.3.16`.

## Not included

- **react-router / react-router-dom (#62, #63, #64)** — breaking v7 major with no fix in the 6.x line. Tracked in #130.
- **`.github/dependabot.yml`** — split out into #132. Independent of this branch; the two can merge in either order.

## Rebase note

This branch was rebuilt on current `origin/main` after discovering that merged PRs #107, #111 and #128 already landed `nanoid` 3.3.18, `postcss` 8.5.26 and `js-yaml` 5.2.3. An earlier local draft would have regressed `postcss` from 8.5.26 back to 8.5.23; those edits were dropped rather than carried forward. Only genuinely outstanding changes remain here.

## Verification

- [x] `ui/package.json` and `ui/package-lock.json` parse
- [x] Lockfile `integrity` values computed from the published tarballs and cross-checked against their upstream sha1 sums — the adm-zip 0.6.0 tarball hashes to `bbc5c6c333755e967a06dd98747f431e1d53a3cf`, matching the registry's published `shasum`
- [x] Dependent ranges re-checked: `brace-expansion@^5.0.9` ✔, postcss → `nanoid@^3.3.16` ✔, nested `minimatch` → `brace-expansion@^1.1.7` still resolves to the separate 1.1.18 entry ✔
- [x] adm-zip API surface used by `@azure/static-web-apps-cli` reviewed against the 0.6.0 changelog — `extractAllTo()` only, unaffected by both behaviour changes
- [ ] **`npm ci` in `ui/` — needs a reviewer with Node.** This machine has no Node/npm and npmjs.org is TLS-blocked, so the lockfile was edited directly rather than regenerated. Hashes are canonical, not guessed, but please confirm the tree resolves.
- [ ] **`swa` smoke test — needs a reviewer with Node.** The adm-zip argument above is source-level, not runtime. The affected paths are the one-time Functions Core Tools and DAB binary downloads, so `swa start` on a clean machine exercises them.

## Reviewer notes

- Pre-existing and untouched: `ui/package-lock.json` declares `rimraf/minimatch → brace-expansion@^2.0.2` with no matching entry in the tree. Likely an artifact of earlier manual lockfile edits; a full `npm install` regeneration would clear it.
- Per repo guardrails this is not auto-merged.
