### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 ---
 # Dependabot configuration for HASTE.
 #
-# Covers five ecosystems: npm (root build tooling + UI), pip (Azure
+# Covers four ecosystems: npm (root build tooling + UI), pip (Azure
 # Functions apps, container requirements, docs, core library), Docker
 # base images, and GitHub Actions.
 #

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,163 @@
+---
+# Dependabot configuration for HASTE.
+#
+# Covers five ecosystems: npm (root build tooling + UI), pip (Azure
+# Functions apps, container requirements, docs, core library), Docker
+# base images, and GitHub Actions.
+#
+# Grouping strategy: security updates for an ecosystem are collapsed into
+# a single PR, and routine minor/patch version updates into another. This
+# matters because a single package can carry several advisories at once --
+# brace-expansion had three open alerts that all resolved to one bump.
+# Ungrouped, that arrives as three PRs where each supersedes the last.
+#
+# Major version updates are deliberately left ungrouped so each one gets
+# its own PR and its own review.
+version: 2
+
+updates:
+  # --- npm -----------------------------------------------------------
+  # "/"    -> root build tooling (vite). Dev/build only, not shipped.
+  # "/ui"  -> React app. Production runtime code.
+  - package-ecosystem: "npm"
+    directories:
+      - "/"
+      - "/ui"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "javascript"
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    groups:
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      npm-minor-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # --- pip -----------------------------------------------------------
+  # hastegeo is ignored on purpose. The api/*/requirements.txt files
+  # install it from the local tree via "-e ../../hastelib", and
+  # hastelib/haste_build.py rewrites those pins repo-wide on every wheel
+  # build. Letting Dependabot bump it would fight that hook.
+  #
+  # Note: hastelib's conda/hatch test environment is not covered here --
+  # Dependabot reads pyproject.toml only.
+  - package-ecosystem: "pip"
+    directories:
+      - "/api/hastefuncapi"
+      - "/api/hastefuncqueues"
+      - "/api/titilerfuncapi"
+      - "/docker/imageryprep"
+      - "/docs"
+      - "/hastelib"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    ignore:
+      - dependency-name: "hastegeo"
+    groups:
+      pip-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      pip-minor-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # --- Docker base images --------------------------------------------
+  # GDAL and CUDA base images pin heavy toolchains, so major bumps are
+  # kept out of the group and reviewed individually.
+  - package-ecosystem: "docker"
+    directories:
+      - "/api/hastefuncapi"
+      - "/api/hastefuncqueues"
+      - "/docker/api"
+      - "/docker/data-init"
+      - "/docker/emulators"
+      - "/docker/imageryprep"
+      - "/docker/titiler"
+      - "/docker/training"
+      - "/docker/ui"
+      - "/ui"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      docker-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      docker-minor-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # --- GitHub Actions ------------------------------------------------
+  # .github/instructions/cicd.instructions.md requires actions to be
+  # pinned to full SHAs. SHA pins never advance on their own, so without
+  # this block they go stale and drift apart between workflows.
+  # Dependabot updates the SHA and keeps the trailing "# v4" comment.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      actions-all:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml`. The repo currently has none, so alerts arrive as ungrouped one-off PRs and nothing keeps SHA-pinned actions or Docker base images current.

Split out from #131, which carries the actual package bumps. No dependency changes here - config only.

## Coverage

| Ecosystem | Directories | PR limit | Labels |
|-----------|-------------|----------|--------|
| npm | `/`, `/ui` | 5 | `dependencies`, `javascript` |
| pip | `/api/hastefuncapi`, `/api/hastefuncqueues`, `/api/titilerfuncapi`, `/docker/imageryprep`, `/docs`, `/hastelib` | 5 | `dependencies`, `python` |
| docker | 10 Dockerfile directories | 3 | `dependencies` |
| github-actions | `/` | 3 | `dependencies` |

Weekly, Mondays 06:00 UTC. `commit-message.prefix: chore` with `include: scope` produces `chore(deps): ...`, matching the conventional-commit convention in `AGENTS.md`.

## Grouping

Each ecosystem declares two groups - one collapsing **security** updates into a single PR, one collapsing routine **minor/patch**. Majors stay ungrouped so each gets its own review.

This is the main motivation. A single package often carries several advisories at once: `brace-expansion` currently has three open alerts (#58, #67, #68) patched in 5.0.7, 5.0.8 and 5.0.9 respectively. Ungrouped, that is three PRs where each supersedes the last - roughly what happened with the `nanoid`/`postcss`/`js-yaml` PRs (#107, #111, #128) that landed while #131 was being prepared.

## Why the github-actions block matters

`.github/instructions/cicd.instructions.md` requires actions pinned to full SHAs. SHA pins never advance on their own, and the pins have already drifted:

- `actions/setup-python@v5` is pinned to `a26af69b...` in four workflows but `42375524...` in `config-drift.yml`
- `docs-deploy.yml`, `codeql.yml` and `secret-scan.yml` still use floating `@v4`/`@v5` tags, contrary to the instruction file

Dependabot updates the SHA and preserves the trailing `# v4` comment, which is what makes SHA-pinning sustainable rather than a one-time snapshot.

## Deliberate exclusions

- **`hastegeo` is ignored under pip.** `api/*/requirements.txt` install it via `-e ../../hastelib`, and `hastelib/haste_build.py` rewrites those pins repo-wide on every wheel build. Dependabot bumping it would fight that hook.
- **`hastelib`'s conda/hatch test environment is not covered** - Dependabot reads `pyproject.toml` only. Worth knowing this leaves a gap in test-env dependency coverage.

## Verification

- [x] YAML parses; no tab characters
- [x] All 19 declared directories confirmed to exist and contain the expected manifest (`package.json` / `requirements.txt` / `pyproject.toml` / `Dockerfile*` / `.github/workflows`)
- [x] All labels referenced (`dependencies`, `javascript`, `python`) exist in the repo

## Reviewer notes

- Please confirm **Dependabot security updates** are enabled in Settings -> Advanced Security. The `applies-to: security-updates` groups are inert without it, and I could not verify - the API returns 404 for my token.
- `open-pull-requests-limit` is set conservatively (3-5 per ecosystem). Expect an initial burst on the first run as Docker and Actions catch up on accumulated drift; the limits cap how much lands at once.
- Schedules are intentionally on one weekday rather than daily, to keep review load predictable.
