### PR TITLE
fix(imagery): remove unused custom source type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ Versioning follows the Docker image tags defined in the CI workflows (see [.gith
 - **Generic-default IaC for reuse by other partners** — `HASTE_RESOURCE_PREFIX` now defaults to the neutral `haste` (overridable per deployment); the shared-pools template keeps its account/ACR as bring-your-own params. The `api`/`queues` Function App identity is granted **Storage Blob Delegator** (in `functionApp.bicep`) so it can mint user-delegation SAS.
 - **Pinned `azure-batch==14.2.0`** — the 15.x track-2 rewrite restructures the batch models this code uses; migration is tracked separately.
 
+### Removed
+- **Unused custom imagery source** — Removed the unused source option and its special-case eight-band preprocessing path. `RGB/NoProcessing` remains available for imagery that does not need provider-specific handling.
+
 ---
 
 ## [v2.0.0] — Building labeling workflow & one-step `azd` setup

--- a/hastelib/src/hastegeo/core/utils/imagery.py
+++ b/hastelib/src/hastegeo/core/utils/imagery.py
@@ -370,23 +370,6 @@ class ImageryUtils:
                     )
                     return [mapping["red"], mapping["green"], mapping["blue"]]
 
-            elif source_type == "mercy_corps":
-                # Mercy Corps specific 8-band order: Coastal Blue, Blue, Green, Yellow, Red, Red Edge, NIR1, NIR2
-                if num_bands == 8:
-                    mapping = map_bands(
-                        [
-                            "coastal blue",
-                            "blue",
-                            "green",
-                            "yellow",
-                            "red",
-                            "red edge",
-                            "nir1",
-                            "nir2",
-                        ]
-                    )
-                    return [mapping["red"], mapping["green"], mapping["blue"]]
-
             elif source_type == "sentinel_2":
                 if num_bands == 13:
                     mapping = map_bands(
@@ -652,12 +635,8 @@ class ImageryUtils:
                     # Use the 2nd and 98th percentiles to reduce the effect of outliers
                     # NOTE: need to identify suitable defaults to use if np.nan.
                     # np.nan will break gdal translate.
-                    lower_percentile = 1 if source_type == "mercy_corps" else 2
-                    upper_percentile = (
-                        99 if source_type == "mercy_corps" else 98
-                    )
-                    p_low = np.percentile(array, lower_percentile)
-                    p_high = np.percentile(array, upper_percentile)
+                    p_low = np.percentile(array, 2)
+                    p_high = np.percentile(array, 98)
                     scale_params.append([p_low, p_high, 0, 255])
                 return scale_params
         except Exception as e:

--- a/hastelib/src/hastegeo/workflows/prepare_imagery.py
+++ b/hastelib/src/hastegeo/workflows/prepare_imagery.py
@@ -796,7 +796,7 @@ def _determine_scale_rgb_params(source_type):
     Returns:
         bool: True if scale RGB parameters are needed, False otherwise.
     """
-    if source_type in ["planet_scope", "planet_skysat", "mercy_corps"]:
+    if source_type in ["planet_scope", "planet_skysat"]:
         return True
     return False
 

--- a/hastelib/tests/core/utils/test_imagery.py
+++ b/hastelib/tests/core/utils/test_imagery.py
@@ -1,0 +1,51 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Tests for imagery utility source-specific behavior."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+from hastegeo.core.utils.imagery import ImageryUtils
+
+
+class TestGetScaleImageryParams(unittest.TestCase):
+    def test_rgb_no_processing_uses_default_percentiles(self):
+        dataset = MagicMock()
+        dataset.__enter__.return_value = dataset
+        dataset.RasterCount = 3
+        dataset.GetRasterBand.return_value.ReadAsArray.return_value = np.array(
+            [0, 1, 2]
+        )
+
+        with (
+            patch(
+                "hastegeo.core.utils.imagery.gdal.Open",
+                return_value=dataset,
+            ),
+            patch(
+                "hastegeo.core.utils.imagery.np.percentile",
+                side_effect=lambda _, percentile: percentile,
+            ) as mock_percentile,
+        ):
+            result = ImageryUtils.get_scale_imagery_params(
+                "image.tif", "rgb/no_processing"
+            )
+
+        self.assertEqual(
+            result,
+            [
+                [2, 98, 0, 255],
+                [2, 98, 0, 255],
+                [2, 98, 0, 255],
+            ],
+        )
+        self.assertEqual(
+            [call.args[1] for call in mock_percentile.call_args_list],
+            [2, 98, 2, 98, 2, 98],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hastelib/tests/workflows/test_prepare_imagery.py
+++ b/hastelib/tests/workflows/test_prepare_imagery.py
@@ -30,7 +30,10 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import shapely.geometry
-from hastegeo.workflows.prepare_imagery import ImageryWorkflow
+from hastegeo.workflows.prepare_imagery import (
+    ImageryWorkflow,
+    _determine_scale_rgb_params,
+)
 
 
 def _fake_polygon():
@@ -555,6 +558,16 @@ class TestProcessUserBuildingFootprintsStep(unittest.TestCase):
                 kwargs = mock_get.call_args.kwargs
                 self.assertFalse(kwargs.get("allow_redirects", True))
                 self.assertEqual(kwargs.get("timeout"), 30)
+
+
+class TestDetermineScaleRgbParams(unittest.TestCase):
+    def test_planet_sources_enable_scaling(self):
+        for source_type in ("planet_scope", "planet_skysat"):
+            with self.subTest(source_type=source_type):
+                self.assertTrue(_determine_scale_rgb_params(source_type))
+
+    def test_rgb_no_processing_does_not_enable_scaling(self):
+        self.assertFalse(_determine_scale_rgb_params("rgb/no_processing"))
 
 
 if __name__ == "__main__":

--- a/ui/src/Components/CreateEditImageLayerHelper.js
+++ b/ui/src/Components/CreateEditImageLayerHelper.js
@@ -8,22 +8,14 @@ import {
   validateFileType,
 } from "../util/validation";
 import { v4 as uuidv4 } from 'uuid';
+import { sourceTypeOptions } from "./sourceTypeOptions.js";
+
+export { sourceTypeOptions };
 
 const imageryOriginOptions = [
     { key: "url", text: "URL" },
     { key: "file", text: "File" },
 ]
-
-export const sourceTypeOptions = [
-    { key: "n/a", text: "Unknown", visualizerText:"Unknown", showInDropdown: true, url: "" },
-    { key: "rgb/no_processing", text: "RGB/NoProcessing", visualizerText:"RGB/NoProcessing", showInDropdown: true, url: "" },
-    { key: "mercy_corps", text: "Custom - Mercy Corps", visualizerText:"Custom - Mercy Corps", showInDropdown: true, url: "" },
-    { key: "maxar", text: "Maxar", visualizerText:"Maxar Open Data Program", showInDropdown: true, url: "https://maxar.com/" },
-    { key: "planet_scope", text: "Planet Scope", visualizerText:"Planet Scope", showInDropdown: true, url: "https://developers.planet.com/docs/data/planetscope" },
-    { key: "planet_skysat", text: "Planet Skysat", visualizerText:"Planet Skysat", showInDropdown: true, url: "https://developers.planet.com/docs/data/skysat" },
-    { key: "sentinel_2", text: "Sentinel 2", visualizerText:"Sentinel 2", showInDropdown: false, url: "https://docs.sentinel-hub.com/api/latest/data/sentinel-2-l2a" },
-    { key: "azure_maps", text: "Azure Maps", visualizerText:"Azure Maps Basemap", showInDropdown: false, url: "https://azure.microsoft.com/en-us/products/azure-maps" },
-];
 
 export async function createComponentDefaultState(imageLayerId, projectId) {
     try {

--- a/ui/src/Components/CreateEditImageLayerHelper.test.js
+++ b/ui/src/Components/CreateEditImageLayerHelper.test.js
@@ -25,3 +25,11 @@ test("keeps RGB no-processing available as a generic source", () => {
   assert.equal(option?.text, "RGB/NoProcessing");
   assert.equal(option?.visualizerText, "RGB/NoProcessing");
 });
+
+test("uses Vantor display metadata for the existing provider key", () => {
+  const option = sourceTypeOptions.find(({ key }) => key === "maxar");
+
+  assert.equal(option?.text, "Vantor");
+  assert.equal(option?.visualizerText, "Vantor Open Data Program");
+  assert.equal(option?.url, "https://vantor.com/");
+});

--- a/ui/src/Components/CreateEditImageLayerHelper.test.js
+++ b/ui/src/Components/CreateEditImageLayerHelper.test.js
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { sourceTypeOptions } from "./sourceTypeOptions.js";
+
+test("lists only the supported visible imagery source types", () => {
+  const visibleSourceKeys = sourceTypeOptions
+    .filter((option) => option.showInDropdown)
+    .map((option) => option.key);
+
+  assert.deepEqual(visibleSourceKeys, [
+    "n/a",
+    "rgb/no_processing",
+    "maxar",
+    "planet_scope",
+    "planet_skysat",
+  ]);
+});
+
+test("keeps RGB no-processing available as a generic source", () => {
+  const option = sourceTypeOptions.find(
+    ({ key }) => key === "rgb/no_processing"
+  );
+
+  assert.equal(option?.text, "RGB/NoProcessing");
+  assert.equal(option?.visualizerText, "RGB/NoProcessing");
+});

--- a/ui/src/Components/sourceTypeOptions.js
+++ b/ui/src/Components/sourceTypeOptions.js
@@ -4,7 +4,7 @@
 export const sourceTypeOptions = [
     { key: "n/a", text: "Unknown", visualizerText:"Unknown", showInDropdown: true, url: "" },
     { key: "rgb/no_processing", text: "RGB/NoProcessing", visualizerText:"RGB/NoProcessing", showInDropdown: true, url: "" },
-    { key: "maxar", text: "Maxar", visualizerText:"Maxar Open Data Program", showInDropdown: true, url: "https://maxar.com/" },
+    { key: "maxar", text: "Vantor", visualizerText:"Vantor Open Data Program", showInDropdown: true, url: "https://vantor.com/" },
     { key: "planet_scope", text: "Planet Scope", visualizerText:"Planet Scope", showInDropdown: true, url: "https://developers.planet.com/docs/data/planetscope" },
     { key: "planet_skysat", text: "Planet Skysat", visualizerText:"Planet Skysat", showInDropdown: true, url: "https://developers.planet.com/docs/data/skysat" },
     { key: "sentinel_2", text: "Sentinel 2", visualizerText:"Sentinel 2", showInDropdown: false, url: "https://docs.sentinel-hub.com/api/latest/data/sentinel-2-l2a" },

--- a/ui/src/Components/sourceTypeOptions.js
+++ b/ui/src/Components/sourceTypeOptions.js
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export const sourceTypeOptions = [
+    { key: "n/a", text: "Unknown", visualizerText:"Unknown", showInDropdown: true, url: "" },
+    { key: "rgb/no_processing", text: "RGB/NoProcessing", visualizerText:"RGB/NoProcessing", showInDropdown: true, url: "" },
+    { key: "maxar", text: "Maxar", visualizerText:"Maxar Open Data Program", showInDropdown: true, url: "https://maxar.com/" },
+    { key: "planet_scope", text: "Planet Scope", visualizerText:"Planet Scope", showInDropdown: true, url: "https://developers.planet.com/docs/data/planetscope" },
+    { key: "planet_skysat", text: "Planet Skysat", visualizerText:"Planet Skysat", showInDropdown: true, url: "https://developers.planet.com/docs/data/skysat" },
+    { key: "sentinel_2", text: "Sentinel 2", visualizerText:"Sentinel 2", showInDropdown: false, url: "https://docs.sentinel-hub.com/api/latest/data/sentinel-2-l2a" },
+    { key: "azure_maps", text: "Azure Maps", visualizerText:"Azure Maps Basemap", showInDropdown: false, url: "https://azure.microsoft.com/en-us/products/azure-maps" },
+];


### PR DESCRIPTION
## Summary

Removes an unused custom imagery source option and its special-case eight-band preprocessing path. `RGB/NoProcessing` remains available for imagery without provider-specific handling. The shared source metadata also uses current Vantor display branding while retaining the existing internal provider key and backend behavior.

## Changes

- remove the unused source from both image-layer source dropdowns and visualizer lookup
- remove its eight-band mapping, percentile override, and workflow scaling selection
- update the visible provider label, visualizer text, and link to Vantor without changing the internal key
- add focused UI and Python regressions and document the source removal in the changelog

## Testing

- [x] `hatch run test:pytest tests\core\utils\test_imagery.py tests\workflows\test_prepare_imagery.py -v` (22 passed)
- [x] `node --test src\Components\CreateEditImageLayerHelper.test.js` (3 passed)
- [x] ESLint on the changed UI files
- [x] `npm run build`
- [x] pre-commit hooks on all changed files

## Review Notes

The internal provider key, backend behavior, documentation, comments, and docstrings remain unchanged. Broader terminology updates are intentionally left for a separate follow-up.