### PR TITLE
feat(ui): add guided loading experience to interactive labeler

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -10,6 +10,7 @@
     "build:dev1": "vite build --mode dev1",
     "build:testing": "vite build --mode testing",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
+    "test:interactive-labeler": "node --test src/Components/InteractiveLabeler/interactiveLabelerLoading.test.js src/Components/guidedTourLayout.test.js",
     "test:ongoing-jobs": "node --test src/Components/Home/ongoingJobs.test.js",
     "test:label-store": "node --test src/Components/InteractiveLabeler/labelStore.test.js",
     "preview": "vite preview"

--- a/ui/src/AppContext.jsx
+++ b/ui/src/AppContext.jsx
@@ -244,6 +244,75 @@ export const AppProvider = ({ children }) => {
         },
       ],
     },
+    {
+      name: "interactiveLabelerGuide",
+      cookieName: "interactiveLabelerGuidedTour",
+      steps: [
+        {
+          type: "teachingBubble",
+          target: "#interactiveLabelerMapArea",
+          title: "Compare and label buildings",
+          content:
+            "Click a building to apply the selected class, right-click to clear it, or hold Ctrl while dragging to label several buildings. Drag the swipe divider to compare pre- and post-event imagery.",
+        },
+        {
+          type: "teachingBubble",
+          target: "#interactiveLabelerClasses",
+          title: "Choose a damage class",
+          content:
+            "Select Intact, Damaged, or Cloudy before labeling. The counters update as you work; you can also press 1, 2, or 3 to change class.",
+        },
+        {
+          type: "teachingBubble",
+          target: "#interactiveLabelerViewControls",
+          title: "Review labels and predictions",
+          content:
+            "After labeling at least three buildings in two classes, switch between your labels and the model predictions. Hide footprints when you need an unobstructed imagery view.",
+        },
+        {
+          type: "teachingBubble",
+          target: "#interactiveLabelerProgress",
+          title: "Track labeling progress",
+          content:
+            "This area reports training activity, the number of labeled buildings, and how many buildings have predictions in the current map view.",
+        },
+        {
+          type: "teachingBubble",
+          target: "#interactiveLabelerActions",
+          title: "Save or predict the full layer",
+          content:
+            "Save labels to continue later. Predict all buildings runs the current model across the full layer and stores the results for validation and assessment reports.",
+        },
+        {
+          type: "teachingBubble",
+          target: "#interactiveLabelerAdvanced",
+          title: "Open advanced review tools",
+          content:
+            "Advanced includes cross-validation, swipe controls, model uncertainty, and a view that highlights labels which disagree with the current prediction.",
+        },
+        {
+          type: "teachingBubble",
+          target: "#interactiveLabelerShortcuts",
+          title: "Work faster with shortcuts",
+          content:
+            "Expand Keyboard shortcuts for the complete reference, including class selection, footprint visibility, box labeling, prediction view, and swipe controls.",
+        },
+        {
+          type: "teachingBubble",
+          target: "#backButton",
+          title: "Return to the project",
+          content:
+            "Use Back to leave the Interactive Labeler. Your work is persisted only after you select Save labels.",
+        },
+        {
+          type: "teachingBubble",
+          target: "#helpButton",
+          title: "Restart this tour",
+          content:
+            "Select Help at any time to restart the Interactive Labeler tour.",
+        },
+      ],
+    },
   ];
 
   const [appParams, setAppParams] = useState({

--- a/ui/src/AppContext.jsx
+++ b/ui/src/AppContext.jsx
@@ -253,7 +253,7 @@ export const AppProvider = ({ children }) => {
           target: "#interactiveLabelerMapArea",
           title: "Compare and label buildings",
           content:
-            "Click a building to apply the selected class, right-click to clear it, or hold Ctrl while dragging to label several buildings. Drag the swipe divider to compare pre- and post-event imagery.",
+            "Click a building to apply the selected class, right-click to clear it, or hold Ctrl while dragging to label several buildings. Open Advanced and enable Swipe to compare pre- and post-event imagery.",
         },
         {
           type: "teachingBubble",

--- a/ui/src/Components/GuidedTour.jsx
+++ b/ui/src/Components/GuidedTour.jsx
@@ -13,6 +13,7 @@ import {
   setGuidedTourState,
   validateIsGuidedTourDisabled,
 } from "./GuidedTourHelper.js";
+import { getTourCardStyle } from "./guidedTourLayout.js";
 
 /** True only when the element exists AND is actually rendered/visible.
  *  Guards against targets that are in the DOM but hidden (e.g. tables
@@ -118,37 +119,11 @@ const GuidedTour = () => {
     const holeW = spot.width + pad * 2;
     const holeH = spot.height + pad * 2;
 
-    const vw = window.innerWidth;
-    const vh = window.innerHeight;
-    const cardW = Math.min(340, vw - 32);
-    const viewportMargin = 16;
-    const cardGap = 14;
-    const preferredCardHeight = 280;
-    const targetBottom = spot.top + spot.height;
-    const spaceBelow = vh - targetBottom - cardGap - viewportMargin;
-    const spaceAbove = spot.top - cardGap - viewportMargin;
-
-    const cardStyle = {
-      position: "fixed",
-      width: cardW,
-      left: Math.max(16, Math.min(holeLeft, vw - cardW - 16)),
-    };
-    if (spaceBelow >= preferredCardHeight) {
-      cardStyle.top = targetBottom + cardGap;
-      cardStyle.maxHeight = vh - cardStyle.top - viewportMargin;
-    } else if (spaceAbove >= preferredCardHeight) {
-      cardStyle.bottom = vh - spot.top + cardGap;
-      cardStyle.maxHeight = spaceAbove;
-    } else {
-      cardStyle.top = Math.max(
-        viewportMargin,
-        Math.min(
-          spot.top + cardGap,
-          vh - preferredCardHeight - viewportMargin
-        )
-      );
-      cardStyle.maxHeight = vh - cardStyle.top - viewportMargin;
-    }
+    const cardStyle = getTourCardStyle(
+      spot,
+      window.innerWidth,
+      window.innerHeight
+    );
 
     const totalSteps = filteedTourSteps.length;
 

--- a/ui/src/Components/GuidedTour.jsx
+++ b/ui/src/Components/GuidedTour.jsx
@@ -121,17 +121,33 @@ const GuidedTour = () => {
     const vw = window.innerWidth;
     const vh = window.innerHeight;
     const cardW = Math.min(340, vw - 32);
-    const placeBelow = spot.top + spot.height + 12 + 220 < vh;
+    const viewportMargin = 16;
+    const cardGap = 14;
+    const preferredCardHeight = 280;
+    const targetBottom = spot.top + spot.height;
+    const spaceBelow = vh - targetBottom - cardGap - viewportMargin;
+    const spaceAbove = spot.top - cardGap - viewportMargin;
 
     const cardStyle = {
       position: "fixed",
       width: cardW,
       left: Math.max(16, Math.min(holeLeft, vw - cardW - 16)),
     };
-    if (placeBelow) {
-      cardStyle.top = spot.top + spot.height + 14;
+    if (spaceBelow >= preferredCardHeight) {
+      cardStyle.top = targetBottom + cardGap;
+      cardStyle.maxHeight = vh - cardStyle.top - viewportMargin;
+    } else if (spaceAbove >= preferredCardHeight) {
+      cardStyle.bottom = vh - spot.top + cardGap;
+      cardStyle.maxHeight = spaceAbove;
     } else {
-      cardStyle.bottom = vh - spot.top + 14;
+      cardStyle.top = Math.max(
+        viewportMargin,
+        Math.min(
+          spot.top + cardGap,
+          vh - preferredCardHeight - viewportMargin
+        )
+      );
+      cardStyle.maxHeight = vh - cardStyle.top - viewportMargin;
     }
 
     const totalSteps = filteedTourSteps.length;

--- a/ui/src/Components/InteractiveLabeler/InteractiveLabeler.jsx
+++ b/ui/src/Components/InteractiveLabeler/InteractiveLabeler.jsx
@@ -44,6 +44,10 @@ import { toBrowserTitilerUrl } from "../../util/blobUrl";
 import { AppContext } from "../../AppContext.jsx";
 import { loadImagery } from "../LabelingTool/LabelingToolHelper.js";
 import {
+  initGuidedTourState,
+  setGuidedTourState,
+} from "../GuidedTourHelper.js";
+import {
   CLASS_CLOUDY,
   CLASS_DAMAGED,
   CLASS_INTACT,
@@ -53,6 +57,7 @@ import {
   isValidVector,
 } from "./interactiveModel.js";
 import { getGpu } from "./gpuLogreg.js";
+import InteractiveLabelerLoader from "./InteractiveLabelerLoader.jsx";
 import KeyboardShortcutHelp from "../KeyboardShortcutHelp.jsx";
 import {
   INTERACTIVE_LABELER_SHORTCUTS,
@@ -108,14 +113,42 @@ class InMemoryPMTilesSource {
 // Download an entire artifact through the same-origin API proxy as raw
 // bytes. Used for the PMTiles archive so it can be read fully in memory
 // (see InMemoryPMTilesSource) rather than via unsupported range requests.
-async function fetchArtifactBuffer(url) {
+async function readResponseBuffer(response, onProgress) {
+  const total = Number(response.headers.get("content-length")) || null;
+  if (!response.body) {
+    const buffer = await response.arrayBuffer();
+    onProgress?.(buffer.byteLength, total || buffer.byteLength);
+    return buffer;
+  }
+
+  const reader = response.body.getReader();
+  const chunks = [];
+  let loaded = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+    loaded += value.byteLength;
+    onProgress?.(loaded, total);
+  }
+
+  const bytes = new Uint8Array(loaded);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes.buffer;
+}
+
+async function fetchArtifactBuffer(url, onProgress) {
   const resp = await fetch(url);
   if (!resp.ok) {
     throw new Error(
       `Failed to fetch PMTiles archive (HTTP ${resp.status}) at ${url}`
     );
   }
-  return resp.arrayBuffer();
+  return readResponseBuffer(resp, onProgress);
 }
 
 // Class colors (match index.html). Index = class number.
@@ -442,7 +475,7 @@ function normalizedEntropy(probs) {
 const SIDECAR_MAGIC = [0x48, 0x46, 0x54, 0x52]; // "HFTR"
 const SIDECAR_VERSION = 1;
 
-async function fetchFeaturesSidecar(url) {
+async function fetchFeaturesSidecar(url, onProgress) {
   const t0 = performance.now();
   const resp = await fetch(url);
   if (!resp.ok) {
@@ -450,7 +483,7 @@ async function fetchFeaturesSidecar(url) {
       `Failed to fetch features sidecar (HTTP ${resp.status}) at ${url}`
     );
   }
-  const buf = await resp.arrayBuffer();
+  const buf = await readResponseBuffer(resp, onProgress);
   if (buf.byteLength < 16) {
     throw new Error("Features sidecar is too short — header missing.");
   }
@@ -499,8 +532,13 @@ const InteractiveLabeler = () => {
   const styles = useStyles();
   const { projectId, imageLayerId, modelId } = useParams();
   const navigate = useNavigate();
-  const { setIsLoading, setDialog, setAppHeaderRightButtons } =
-    useContext(AppContext);
+  const {
+    appParams,
+    initCurrentTour,
+    setIsLoading,
+    setDialog,
+    setAppHeaderRightButtons,
+  } = useContext(AppContext);
 
   const mapContainerRef = useRef(null);
   const mapRef = useRef(null);
@@ -581,6 +619,11 @@ const InteractiveLabeler = () => {
   const swipeBoxCleanupRef = useRef(null);
 
   const [isMapReady, setIsMapReady] = useState(false);
+  const [initialLoad, setInitialLoad] = useState({
+    step: 0,
+    loaded: null,
+    total: null,
+  });
   const [selectedClass, setSelectedClass] = useState(CLASS_DAMAGED);
   const [viewMode, setViewMode] = useState("label"); // "label" | "predict"
   const [showFootprints, setShowFootprints] = useState(true);
@@ -651,22 +694,21 @@ const InteractiveLabeler = () => {
   useEffect(() => {
     const init = async () => {
       if (!window.atlas) return;
-      setIsLoading(true, "Loading Interactive Labeler");
       try {
         await createMap();
         setIsMapReady(true);
+        setInitialLoad(null);
       } catch (e) {
         console.error("Error initializing interactive labeler:", e);
         setDialog(
           "Error",
           `Failed to load the interactive labeler: ${e?.message || e}`
         );
-      } finally {
-        setIsLoading(false);
       }
     };
     init();
     return () => {
+      initCurrentTour(null);
       setAppHeaderRightButtons([]);
       // Read at teardown on purpose: setupBoxSelect registers this well after
       // the effect runs, so copying the ref up front would capture null and
@@ -688,7 +730,34 @@ const InteractiveLabeler = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  useEffect(() => {
+    if (!isMapReady) return;
+    initGuidedTourState(
+      "interactiveLabelerGuide",
+      appParams.guidedTourProperties
+    );
+    initCurrentTour("interactiveLabelerGuide");
+    setAppHeaderRightButtons([
+      {
+        iconName: "help",
+        title: "Help",
+        id: "helpButton",
+        onClick: () =>
+          setGuidedTourState(
+            false,
+            initCurrentTour,
+            "interactiveLabelerGuide",
+            appParams.guidedTourProperties
+          ),
+      },
+    ]);
+    // Tour configuration is stable for the mounted labeler. Re-running this
+    // effect on AppContext updates would restart the tour at every step.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isMapReady]);
+
   async function createMap() {
+    setInitialLoad({ step: 0, loaded: null, total: null });
     let layerData = null;
     try {
       layerData = await apiGet(
@@ -707,6 +776,7 @@ const InteractiveLabeler = () => {
     // populated by the embedding workflow's postprocessor.
     let pmtilesUrl = "";
     let sidecarUrl = "";
+    setInitialLoad({ step: 1, loaded: null, total: null });
     try {
       const models = await apiGet(
         `GetLayerModelsDetails?projectId=${projectId}&imageLayerId=${imageLayerId}`
@@ -751,8 +821,12 @@ const InteractiveLabeler = () => {
     // read hit the local buffer instead of the network. `getKey()` returns
     // browserPmtilesUrl so it matches the `pmtiles://<url>` source below.
     let pmtilesHeader = null;
+    setInitialLoad({ step: 2, loaded: 0, total: null });
     try {
-      const pmtilesBuffer = await fetchArtifactBuffer(browserPmtilesUrl);
+      const pmtilesBuffer = await fetchArtifactBuffer(
+        browserPmtilesUrl,
+        (loaded, total) => setInitialLoad({ step: 2, loaded, total })
+      );
       const pm = new PMTiles(
         new InMemoryPMTilesSource(browserPmtilesUrl, pmtilesBuffer)
       );
@@ -770,14 +844,17 @@ const InteractiveLabeler = () => {
     // f_* lookup downstream — the PMTiles archive itself only carries id +
     // overture_id, so the labeler reads feature vectors here, not from
     // tile properties.
-    setIsLoading(true, "Loading features…");
-    sidecarRef.current = await fetchFeaturesSidecar(browserSidecarUrl);
-    setIsLoading(true, "Loading Interactive Labeler");
+    setInitialLoad({ step: 3, loaded: 0, total: null });
+    sidecarRef.current = await fetchFeaturesSidecar(
+      browserSidecarUrl,
+      (loaded, total) => setInitialLoad({ step: 3, loaded, total })
+    );
 
     // Restore this model's previously-saved interactive labels (separate from
     // the Building Validation store). Labels are keyed by overture id; we
     // re-apply them as feature-state on each moveend hydration when the
     // matching building's tile is in view.
+    setInitialLoad({ step: 4, loaded: null, total: null });
     try {
       const saved = await apiGet(
         `GetInteractiveLabels?projectId=${projectId}&modelId=${modelId}`
@@ -822,6 +899,7 @@ const InteractiveLabeler = () => {
       initialCamera = { center: [centerLon, centerLat], zoom };
     }
 
+    setInitialLoad({ step: 5, loaded: null, total: null });
     const map = new window.atlas.Map(mapContainerRef.current, {
       ...initialCamera,
       maxPitch: 0,
@@ -831,7 +909,7 @@ const InteractiveLabeler = () => {
       authOptions: getAzureMapsAuthOptions(),
     });
 
-    map.events.add("ready", () => {
+    await new Promise((resolve) => map.events.add("ready", () => {
       map.setUserInteraction({
         dragRotateInteraction: false,
         scrollZoomInteraction: true,
@@ -1026,7 +1104,8 @@ const InteractiveLabeler = () => {
       };
       map.events.add("move", syncInfo);
       syncInfo();
-    });
+      resolve();
+    }));
 
     mapRef.current = map;
   }
@@ -2394,6 +2473,7 @@ const InteractiveLabeler = () => {
 
   return (
     <div className={styles.root}>
+      <InteractiveLabelerLoader loadState={initialLoad} />
       <div
         className="labeling-tool-surface labeling-navigation-controls"
         style={{
@@ -2424,7 +2504,10 @@ const InteractiveLabeler = () => {
           handle (z-index:1, appended into the primary/pre container) still
           paints above both. The pre-map overlay stays display:none until the
           swipe toggle is on. */}
-      <div style={{ position: "relative", flexGrow: 1 }}>
+      <div
+        id="interactiveLabelerMapArea"
+        style={{ position: "relative", flexGrow: 1 }}
+      >
         {/* FIRST/behind: swipe PRIMARY = the new pre-event map (built on
             demand by the swipe effect while the toggle is on). */}
         <div
@@ -2573,55 +2656,59 @@ const InteractiveLabeler = () => {
             </div>
           )}
 
-          <Field label="Set class">
-            <RadioGroup
-              value={String(selectedClass)}
-              onChange={(_e, data) => setSelectedClass(parseInt(data.value, 10))}
-            >
-              {CLASS_OPTIONS.map((o) => (
-                <Radio key={o.key} value={o.key} label={o.text} />
-              ))}
-            </RadioGroup>
-          </Field>
+          <div id="interactiveLabelerClasses">
+            <Field label="Set class">
+              <RadioGroup
+                value={String(selectedClass)}
+                onChange={(_e, data) => setSelectedClass(parseInt(data.value, 10))}
+              >
+                {CLASS_OPTIONS.map((o) => (
+                  <Radio key={o.key} value={o.key} label={o.text} />
+                ))}
+              </RadioGroup>
+            </Field>
 
-          <div style={{ marginTop: 8, fontSize: 13 }}>
-            <div style={{ color: CLASS_COLORS[CLASS_INTACT] }}>
-              Intact: <b>{counts[CLASS_INTACT]}</b>
-            </div>
-            <div style={{ color: CLASS_COLORS[CLASS_DAMAGED] }}>
-              Damaged: <b>{counts[CLASS_DAMAGED]}</b>
-            </div>
-            <div style={{ color: CLASS_COLORS[CLASS_CLOUDY] }}>
-              Cloudy: <b>{counts[CLASS_CLOUDY]}</b>
+            <div style={{ marginTop: 8, fontSize: 13 }}>
+              <div style={{ color: CLASS_COLORS[CLASS_INTACT] }}>
+                Intact: <b>{counts[CLASS_INTACT]}</b>
+              </div>
+              <div style={{ color: CLASS_COLORS[CLASS_DAMAGED] }}>
+                Damaged: <b>{counts[CLASS_DAMAGED]}</b>
+              </div>
+              <div style={{ color: CLASS_COLORS[CLASS_CLOUDY] }}>
+                Cloudy: <b>{counts[CLASS_CLOUDY]}</b>
+              </div>
             </div>
           </div>
 
-          <Switch
-            label="View: Predicted / Labeled"
-            checked={viewMode === "predict"}
-            disabled={!canTrain}
-            onChange={(_e, data) => {
-              setViewMode(data.checked ? "predict" : "label");
-              // Model-driven review views are mutually exclusive.
-              if (data.checked) {
-                setUncertaintyOn(false);
-                setMisclassifiedOn(false);
-              }
-            }}
-            style={{ marginTop: 12 }}
-          />
-          {!canTrain && (
-            <div className={styles.secondaryText} style={{ fontSize: 11, marginTop: -4 }}>
-              Predicted / Uncertainty views need {MIN_PER_CLASS}+ labels in at
-              least 2 classes.
-            </div>
-          )}
+          <div id="interactiveLabelerViewControls">
+            <Switch
+              label="View: Predicted / Labeled"
+              checked={viewMode === "predict"}
+              disabled={!canTrain}
+              onChange={(_e, data) => {
+                setViewMode(data.checked ? "predict" : "label");
+                // Model-driven review views are mutually exclusive.
+                if (data.checked) {
+                  setUncertaintyOn(false);
+                  setMisclassifiedOn(false);
+                }
+              }}
+              style={{ marginTop: 12 }}
+            />
+            {!canTrain && (
+              <div className={styles.secondaryText} style={{ fontSize: 11, marginTop: -4 }}>
+                Predicted / Uncertainty views need {MIN_PER_CLASS}+ labels in at
+                least 2 classes.
+              </div>
+            )}
 
-          <Switch
-            label="Footprints"
-            checked={showFootprints}
-            onChange={(_e, data) => setShowFootprints(!!data.checked)}
-          />
+            <Switch
+              label="Footprints"
+              checked={showFootprints}
+              onChange={(_e, data) => setShowFootprints(!!data.checked)}
+            />
+          </div>
 
           {metrics && (
             <div className={styles.section} style={{ fontSize: 12 }}>
@@ -2645,47 +2732,52 @@ const InteractiveLabeler = () => {
             </div>
           )}
 
-          <div
-            className={styles.secondaryText}
-            style={{
-              marginTop: 8,
-              minHeight: 18,
-              fontSize: 12,
-            }}
-          >
-            {status}
-          </div>
-          <div className={styles.secondaryText} style={{ marginTop: 4, fontSize: 12 }}>
-            {totalLabeled} labeled · {viewportPredicted} predicted in viewport
+          <div id="interactiveLabelerProgress">
+            <div
+              className={styles.secondaryText}
+              style={{
+                marginTop: 8,
+                minHeight: 18,
+                fontSize: 12,
+              }}
+            >
+              {status}
+            </div>
+            <div className={styles.secondaryText} style={{ marginTop: 4, fontSize: 12 }}>
+              {totalLabeled} labeled · {viewportPredicted} predicted in viewport
+            </div>
           </div>
 
-          <Button
-            appearance="primary"
-            disabled={isSaving || totalLabeled === 0}
-            onClick={handleSaveLabels}
-            style={{ marginTop: 16, width: "100%" }}
-          >
-            {isSaving ? "Saving…" : "Save labels"}
-          </Button>
-          <Button
-            disabled={!!fullPredict || !canTrain}
-            onClick={handlePredictAll}
-            style={{ marginTop: 8, width: "100%" }}
-            title="Run the trained model across every building in the layer (not just the viewport) and persist the predictions for the Validation / Assessment reports."
-          >
-            Predict all buildings
-          </Button>
-          <Button
-            onClick={handleClearLabels}
-            className={styles.dangerButton}
-            title="Remove every label for this model — both in-session and in the saved store."
-          >
-            Clear labels
-          </Button>
+          <div id="interactiveLabelerActions">
+            <Button
+              appearance="primary"
+              disabled={isSaving || totalLabeled === 0}
+              onClick={handleSaveLabels}
+              style={{ marginTop: 16, width: "100%" }}
+            >
+              {isSaving ? "Saving…" : "Save labels"}
+            </Button>
+            <Button
+              disabled={!!fullPredict || !canTrain}
+              onClick={handlePredictAll}
+              style={{ marginTop: 8, width: "100%" }}
+              title="Run the trained model across every building in the layer (not just the viewport) and persist the predictions for the Validation / Assessment reports."
+            >
+              Predict all buildings
+            </Button>
+            <Button
+              onClick={handleClearLabels}
+              className={styles.dangerButton}
+              title="Remove every label for this model — both in-session and in the saved store."
+            >
+              Clear labels
+            </Button>
+          </div>
 
           {/* Advanced: expandable container for the 5-fold CV report and the
               swipe (pre-event) comparison view. */}
           <Button
+            id="interactiveLabelerAdvanced"
             appearance="subtle"
             icon={<FluentIcon name={advancedOpen ? "ChevronDown" : "ChevronRight"} />}
             onClick={() => setAdvancedOpen((v) => !v)}
@@ -2864,12 +2956,13 @@ const InteractiveLabeler = () => {
           )}
           </div>
 
-          <div className={styles.footerHelp}>
+          <div id="interactiveLabelerShortcuts" className={styles.footerHelp}>
             <div style={{ marginBottom: 8 }}>
               Click a building to label it · right-click to clear it
             </div>
             <KeyboardShortcutHelp
               shortcuts={INTERACTIVE_LABELER_SHORTCUTS}
+              defaultExpanded={false}
             />
           </div>
         </div>

--- a/ui/src/Components/InteractiveLabeler/InteractiveLabeler.jsx
+++ b/ui/src/Components/InteractiveLabeler/InteractiveLabeler.jsx
@@ -58,7 +58,7 @@ import {
 } from "./interactiveModel.js";
 import { getGpu } from "./gpuLogreg.js";
 import InteractiveLabelerLoader from "./InteractiveLabelerLoader.jsx";
-import { waitForMapReady } from "./interactiveLabelerLoading.js";
+import { readResponseBuffer, waitForMapReady } from "./interactiveLabelerLoading.js";
 import KeyboardShortcutHelp from "../KeyboardShortcutHelp.jsx";
 import {
   INTERACTIVE_LABELER_SHORTCUTS,
@@ -114,34 +114,6 @@ class InMemoryPMTilesSource {
 // Download an entire artifact through the same-origin API proxy as raw
 // bytes. Used for the PMTiles archive so it can be read fully in memory
 // (see InMemoryPMTilesSource) rather than via unsupported range requests.
-async function readResponseBuffer(response, onProgress) {
-  const total = Number(response.headers.get("content-length")) || null;
-  if (!response.body) {
-    const buffer = await response.arrayBuffer();
-    onProgress?.(buffer.byteLength, total || buffer.byteLength);
-    return buffer;
-  }
-
-  const reader = response.body.getReader();
-  const chunks = [];
-  let loaded = 0;
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    chunks.push(value);
-    loaded += value.byteLength;
-    onProgress?.(loaded, total);
-  }
-
-  const bytes = new Uint8Array(loaded);
-  let offset = 0;
-  for (const chunk of chunks) {
-    bytes.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return bytes.buffer;
-}
-
 async function fetchArtifactBuffer(url, onProgress, signal) {
   const resp = await fetch(url, { signal });
   if (!resp.ok) {
@@ -620,6 +592,11 @@ const InteractiveLabeler = () => {
   const swipeBoxCleanupRef = useRef(null);
 
   const [isMapReady, setIsMapReady] = useState(false);
+  // Bumped by the error dialog's Retry action. The initialization effect keys
+  // off this, so a failed load can be started over without remounting the
+  // route (which is otherwise the only way back from a disposed map).
+  const [initAttempt, setInitAttempt] = useState(0);
+  const [loadError, setLoadError] = useState(null);
   const [initialLoad, setInitialLoad] = useState({
     step: 0,
     loaded: null,
@@ -694,8 +671,13 @@ const InteractiveLabeler = () => {
 
   useEffect(() => {
     const controller = new AbortController();
+    // A retry runs this effect again after the cleanup below flagged the old
+    // map as disposed. Clear the flag or hydrateViewport would bail forever
+    // and no label would ever paint on the new map.
+    mapDisposedRef.current = false;
     const init = async () => {
       try {
+        setLoadError(null);
         if (!window.atlas) {
           throw new Error("Azure Maps is unavailable.");
         }
@@ -707,29 +689,15 @@ const InteractiveLabeler = () => {
         console.error("Error initializing interactive labeler:", e);
         setInitialLoad(null);
         if (mapRef.current) {
+          mapDisposedRef.current = true;
           mapRef.current.dispose();
           mapRef.current = null;
         }
-        setDialog(
-          "Interactive Labeler could not load",
-          `Failed to load the interactive labeler: ${e?.message || e}`,
-          [
-            {
-              type: "primary",
-              key: "back",
-              text: "Go back",
-              onClick: () => {
-                setDialog();
-                navigate(-1);
-              },
-            },
-            {
-              type: "default",
-              key: "close",
-              text: "Close",
-              onClick: () => setDialog(),
-            },
-          ]
+        // Surfaced by InteractiveLabelerLoader as a persistent overlay with a
+        // Retry action. A modal dialog would be dismissable (Escape,
+        // backdrop) straight onto a blank labeler with no way back.
+        setLoadError(
+          `Failed to load the interactive labeler: ${e?.message || e}`
         );
       }
     };
@@ -756,7 +724,7 @@ const InteractiveLabeler = () => {
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [initAttempt]);
 
   useEffect(() => {
     if (!isMapReady) return;
@@ -2505,7 +2473,12 @@ const InteractiveLabeler = () => {
 
   return (
     <div className={styles.root}>
-      <InteractiveLabelerLoader loadState={initialLoad} />
+      <InteractiveLabelerLoader
+        loadState={initialLoad}
+        error={loadError}
+        onRetry={() => setInitAttempt((attempt) => attempt + 1)}
+        onGoBack={() => navigate(-1)}
+      />
       <div
         className="labeling-tool-surface labeling-navigation-controls"
         style={{

--- a/ui/src/Components/InteractiveLabeler/InteractiveLabeler.jsx
+++ b/ui/src/Components/InteractiveLabeler/InteractiveLabeler.jsx
@@ -58,6 +58,7 @@ import {
 } from "./interactiveModel.js";
 import { getGpu } from "./gpuLogreg.js";
 import InteractiveLabelerLoader from "./InteractiveLabelerLoader.jsx";
+import { waitForMapReady } from "./interactiveLabelerLoading.js";
 import KeyboardShortcutHelp from "../KeyboardShortcutHelp.jsx";
 import {
   INTERACTIVE_LABELER_SHORTCUTS,
@@ -141,8 +142,8 @@ async function readResponseBuffer(response, onProgress) {
   return bytes.buffer;
 }
 
-async function fetchArtifactBuffer(url, onProgress) {
-  const resp = await fetch(url);
+async function fetchArtifactBuffer(url, onProgress, signal) {
+  const resp = await fetch(url, { signal });
   if (!resp.ok) {
     throw new Error(
       `Failed to fetch PMTiles archive (HTTP ${resp.status}) at ${url}`
@@ -475,9 +476,9 @@ function normalizedEntropy(probs) {
 const SIDECAR_MAGIC = [0x48, 0x46, 0x54, 0x52]; // "HFTR"
 const SIDECAR_VERSION = 1;
 
-async function fetchFeaturesSidecar(url, onProgress) {
+async function fetchFeaturesSidecar(url, onProgress, signal) {
   const t0 = performance.now();
-  const resp = await fetch(url);
+  const resp = await fetch(url, { signal });
   if (!resp.ok) {
     throw new Error(
       `Failed to fetch features sidecar (HTTP ${resp.status}) at ${url}`
@@ -692,22 +693,49 @@ const InteractiveLabeler = () => {
   }, []);
 
   useEffect(() => {
+    const controller = new AbortController();
     const init = async () => {
-      if (!window.atlas) return;
       try {
-        await createMap();
+        if (!window.atlas) {
+          throw new Error("Azure Maps is unavailable.");
+        }
+        await createMap(controller.signal);
         setIsMapReady(true);
         setInitialLoad(null);
       } catch (e) {
+        if (e?.name === "AbortError") return;
         console.error("Error initializing interactive labeler:", e);
+        setInitialLoad(null);
+        if (mapRef.current) {
+          mapRef.current.dispose();
+          mapRef.current = null;
+        }
         setDialog(
-          "Error",
-          `Failed to load the interactive labeler: ${e?.message || e}`
+          "Interactive Labeler could not load",
+          `Failed to load the interactive labeler: ${e?.message || e}`,
+          [
+            {
+              type: "primary",
+              key: "back",
+              text: "Go back",
+              onClick: () => {
+                setDialog();
+                navigate(-1);
+              },
+            },
+            {
+              type: "default",
+              key: "close",
+              text: "Close",
+              onClick: () => setDialog(),
+            },
+          ]
         );
       }
     };
     init();
     return () => {
+      controller.abort();
       initCurrentTour(null);
       setAppHeaderRightButtons([]);
       // Read at teardown on purpose: setupBoxSelect registers this well after
@@ -756,7 +784,8 @@ const InteractiveLabeler = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isMapReady]);
 
-  async function createMap() {
+  async function createMap(signal) {
+    signal.throwIfAborted();
     setInitialLoad({ step: 0, loaded: null, total: null });
     let layerData = null;
     try {
@@ -766,6 +795,7 @@ const InteractiveLabeler = () => {
     } catch {
       // Imagery is optional — labeling works without it.
     }
+    signal.throwIfAborted();
     // Cache the imagery URLs for the Advanced → Swipe view, which loads the
     // pre-event tiles onto its secondary map (falls back to satellite when
     // the layer has no pre-event imagery).
@@ -789,6 +819,7 @@ const InteractiveLabeler = () => {
     } catch (e) {
       console.warn("Could not fetch model URLs:", e);
     }
+    signal.throwIfAborted();
     if (!pmtilesUrl) {
       throw new Error(
         "No PMTiles available for this model — the embedding workflow has not produced building tiles."
@@ -825,7 +856,8 @@ const InteractiveLabeler = () => {
     try {
       const pmtilesBuffer = await fetchArtifactBuffer(
         browserPmtilesUrl,
-        (loaded, total) => setInitialLoad({ step: 2, loaded, total })
+        (loaded, total) => setInitialLoad({ step: 2, loaded, total }),
+        signal
       );
       const pm = new PMTiles(
         new InMemoryPMTilesSource(browserPmtilesUrl, pmtilesBuffer)
@@ -847,7 +879,8 @@ const InteractiveLabeler = () => {
     setInitialLoad({ step: 3, loaded: 0, total: null });
     sidecarRef.current = await fetchFeaturesSidecar(
       browserSidecarUrl,
-      (loaded, total) => setInitialLoad({ step: 3, loaded, total })
+      (loaded, total) => setInitialLoad({ step: 3, loaded, total }),
+      signal
     );
 
     // Restore this model's previously-saved interactive labels (separate from
@@ -871,6 +904,7 @@ const InteractiveLabeler = () => {
       savedLabelsLoadedRef.current = false;
       console.error("Failed to load saved interactive labels:", e);
     }
+    signal.throwIfAborted();
     // Restore everything we can before the map exists. Labels saved with a
     // rowId resolve straight against the sidecar, so the counts are right on
     // first paint instead of climbing as the user pans. Anything older falls
@@ -908,8 +942,9 @@ const InteractiveLabeler = () => {
       language: "en-US",
       authOptions: getAzureMapsAuthOptions(),
     });
+    mapRef.current = map;
 
-    await new Promise((resolve) => map.events.add("ready", () => {
+    await waitForMapReady(map, { signal, onReady: () => {
       map.setUserInteraction({
         dragRotateInteraction: false,
         scrollZoomInteraction: true,
@@ -1104,10 +1139,7 @@ const InteractiveLabeler = () => {
       };
       map.events.add("move", syncInfo);
       syncInfo();
-      resolve();
-    }));
-
-    mapRef.current = map;
+    }});
   }
 
   // ── Internal-map helpers ──────────────────────────────────────────────────

--- a/ui/src/Components/InteractiveLabeler/InteractiveLabelerLoader.jsx
+++ b/ui/src/Components/InteractiveLabeler/InteractiveLabelerLoader.jsx
@@ -1,0 +1,190 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import PropTypes from "prop-types";
+import {
+  ProgressBar,
+  Spinner,
+  makeStyles,
+  tokens,
+} from "@fluentui/react-components";
+import { FluentIcon } from "../../util/icons";
+
+const LOAD_STEPS = [
+  "Loading imagery configuration",
+  "Finding model artifacts",
+  "Loading building tiles",
+  "Loading model features",
+  "Restoring saved labels",
+  "Preparing the map",
+];
+
+const useStyles = makeStyles({
+  overlay: {
+    position: "absolute",
+    inset: 0,
+    zIndex: 2100,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: tokens.spacingHorizontalL,
+    backgroundColor: tokens.colorNeutralBackgroundAlpha2,
+    backdropFilter: "blur(3px)",
+  },
+  dialog: {
+    boxSizing: "border-box",
+    width: "min(440px, calc(100vw - 32px))",
+    padding: tokens.spacingHorizontalXXL,
+    borderRadius: tokens.borderRadiusLarge,
+    color: tokens.colorNeutralForeground1,
+    backgroundColor: tokens.colorNeutralBackground1,
+    border: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStroke2}`,
+    boxShadow: tokens.shadow64,
+  },
+  eyebrow: {
+    color: tokens.colorBrandForeground1,
+    fontSize: tokens.fontSizeBase100,
+    fontWeight: tokens.fontWeightSemibold,
+    textTransform: "uppercase",
+  },
+  title: {
+    margin: `${tokens.spacingVerticalXS} 0 ${tokens.spacingVerticalXS}`,
+    fontSize: tokens.fontSizeBase500,
+    lineHeight: tokens.lineHeightBase600,
+    fontWeight: tokens.fontWeightSemibold,
+  },
+  summary: {
+    display: "flex",
+    justifyContent: "space-between",
+    gap: tokens.spacingHorizontalM,
+    marginBottom: tokens.spacingVerticalS,
+    color: tokens.colorNeutralForeground3,
+    fontSize: tokens.fontSizeBase200,
+  },
+  steps: {
+    display: "grid",
+    gap: tokens.spacingVerticalS,
+    margin: `${tokens.spacingVerticalL} 0 0`,
+    padding: 0,
+    listStyle: "none",
+  },
+  step: {
+    display: "grid",
+    gridTemplateColumns: "20px minmax(0, 1fr) auto",
+    alignItems: "center",
+    gap: tokens.spacingHorizontalS,
+    minHeight: "24px",
+    color: tokens.colorNeutralForeground3,
+    fontSize: tokens.fontSizeBase200,
+  },
+  active: {
+    color: tokens.colorNeutralForeground1,
+    fontWeight: tokens.fontWeightSemibold,
+  },
+  done: {
+    color: tokens.colorNeutralForeground2,
+  },
+  icon: {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    color: tokens.colorBrandForeground1,
+  },
+  pending: {
+    width: "6px",
+    height: "6px",
+    borderRadius: "50%",
+    backgroundColor: tokens.colorNeutralStroke1,
+  },
+  weight: {
+    color: tokens.colorNeutralForeground3,
+    fontSize: tokens.fontSizeBase100,
+    fontWeight: tokens.fontWeightRegular,
+    whiteSpace: "nowrap",
+  },
+});
+
+function formatBytes(bytes) {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "";
+  const units = ["B", "KB", "MB", "GB"];
+  const unitIndex = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(1024)),
+    units.length - 1
+  );
+  const value = bytes / 1024 ** unitIndex;
+  const decimalPlaces = unitIndex === 2 ? 1 : unitIndex === 0 || value >= 10 ? 0 : 1;
+  return `${value.toFixed(decimalPlaces)} ${units[unitIndex]}`;
+}
+
+const InteractiveLabelerLoader = ({ loadState }) => {
+  const styles = useStyles();
+  if (!loadState) return null;
+
+  const activeStep = Math.min(loadState.step, LOAD_STEPS.length - 1);
+
+  return (
+    <div
+      className={styles.overlay}
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      <div className={styles.dialog}>
+        <div className={styles.eyebrow}>Interactive labeler</div>
+        <h2 className={styles.title}>Preparing your workspace</h2>
+        <div className={styles.summary}>
+          <span>{LOAD_STEPS[activeStep]}</span>
+          <span>
+            Step {activeStep + 1} of {LOAD_STEPS.length}
+          </span>
+        </div>
+        <ProgressBar
+          value={activeStep / LOAD_STEPS.length}
+          max={1}
+          aria-label={`Loading step ${activeStep + 1} of ${LOAD_STEPS.length}`}
+        />
+        <ol className={styles.steps}>
+          {LOAD_STEPS.map((label, index) => {
+            const isDone = index < activeStep;
+            const isActive = index === activeStep;
+            const weight =
+              isActive && loadState.loaded
+                ? loadState.total
+                  ? `${formatBytes(loadState.loaded)} of ${formatBytes(loadState.total)}`
+                  : `${formatBytes(loadState.loaded)} loaded`
+                : "";
+            return (
+              <li
+                className={`${styles.step} ${
+                  isActive ? styles.active : isDone ? styles.done : ""
+                }`}
+                key={label}
+              >
+                <span className={styles.icon} aria-hidden="true">
+                  {isDone ? (
+                    <FluentIcon name="Checkmark" />
+                  ) : isActive ? (
+                    <Spinner size="extra-tiny" />
+                  ) : (
+                    <span className={styles.pending} />
+                  )}
+                </span>
+                <span>{label}</span>
+                {weight && <span className={styles.weight}>{weight}</span>}
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+    </div>
+  );
+};
+
+InteractiveLabelerLoader.propTypes = {
+  loadState: PropTypes.shape({
+    step: PropTypes.number.isRequired,
+    loaded: PropTypes.number,
+    total: PropTypes.number,
+  }),
+};
+
+export default InteractiveLabelerLoader;

--- a/ui/src/Components/InteractiveLabeler/InteractiveLabelerLoader.jsx
+++ b/ui/src/Components/InteractiveLabeler/InteractiveLabelerLoader.jsx
@@ -8,6 +8,7 @@ import {
   tokens,
 } from "@fluentui/react-components";
 import { FluentIcon } from "../../util/icons";
+import { formatBytes, getLoadProgress } from "./interactiveLabelerLoading.js";
 
 const LOAD_STEPS = [
   "Loading imagery configuration",
@@ -103,18 +104,6 @@ const useStyles = makeStyles({
   },
 });
 
-function formatBytes(bytes) {
-  if (!Number.isFinite(bytes) || bytes <= 0) return "";
-  const units = ["B", "KB", "MB", "GB"];
-  const unitIndex = Math.min(
-    Math.floor(Math.log(bytes) / Math.log(1024)),
-    units.length - 1
-  );
-  const value = bytes / 1024 ** unitIndex;
-  const decimalPlaces = unitIndex === 2 ? 1 : unitIndex === 0 || value >= 10 ? 0 : 1;
-  return `${value.toFixed(decimalPlaces)} ${units[unitIndex]}`;
-}
-
 const InteractiveLabelerLoader = ({ loadState }) => {
   const styles = useStyles();
   if (!loadState) return null;
@@ -138,7 +127,7 @@ const InteractiveLabelerLoader = ({ loadState }) => {
           </span>
         </div>
         <ProgressBar
-          value={activeStep / LOAD_STEPS.length}
+          value={getLoadProgress(activeStep, LOAD_STEPS.length)}
           max={1}
           aria-label={`Loading step ${activeStep + 1} of ${LOAD_STEPS.length}`}
         />

--- a/ui/src/Components/InteractiveLabeler/InteractiveLabelerLoader.jsx
+++ b/ui/src/Components/InteractiveLabeler/InteractiveLabelerLoader.jsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import PropTypes from "prop-types";
 import {
+  Button,
   ProgressBar,
   Spinner,
   makeStyles,
@@ -102,11 +103,52 @@ const useStyles = makeStyles({
     fontWeight: tokens.fontWeightRegular,
     whiteSpace: "nowrap",
   },
+  errorIcon: {
+    color: tokens.colorPaletteRedForeground1,
+  },
+  message: {
+    margin: `${tokens.spacingVerticalS} 0 0`,
+    color: tokens.colorNeutralForeground2,
+    fontSize: tokens.fontSizeBase300,
+    lineHeight: tokens.lineHeightBase400,
+    overflowWrap: "anywhere",
+  },
+  actions: {
+    display: "flex",
+    justifyContent: "flex-end",
+    gap: tokens.spacingHorizontalS,
+    marginTop: tokens.spacingVerticalL,
+  },
 });
 
-const InteractiveLabelerLoader = ({ loadState }) => {
+const InteractiveLabelerLoader = ({ loadState, error, onRetry, onGoBack }) => {
   const styles = useStyles();
-  if (!loadState) return null;
+  if (!loadState && !error) return null;
+
+  // The failure overlay is deliberately part of the labeler rather than a
+  // transient dialog: dismissing the dialog (Escape, backdrop) would
+  // otherwise leave a disposed map behind with no way to start over.
+  if (error) {
+    return (
+      <div className={styles.overlay} role="alert" aria-live="assertive">
+        <div className={styles.dialog}>
+          <div className={`${styles.eyebrow} ${styles.errorIcon}`}>
+            Interactive labeler
+          </div>
+          <h2 className={styles.title}>Could not load the labeler</h2>
+          <p className={styles.message}>{error}</p>
+          <div className={styles.actions}>
+            {onGoBack && <Button onClick={onGoBack}>Go back</Button>}
+            {onRetry && (
+              <Button appearance="primary" onClick={onRetry}>
+                Retry
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   const activeStep = Math.min(loadState.step, LOAD_STEPS.length - 1);
 
@@ -174,6 +216,9 @@ InteractiveLabelerLoader.propTypes = {
     loaded: PropTypes.number,
     total: PropTypes.number,
   }),
+  error: PropTypes.string,
+  onRetry: PropTypes.func,
+  onGoBack: PropTypes.func,
 };
 
 export default InteractiveLabelerLoader;

--- a/ui/src/Components/InteractiveLabeler/interactiveLabelerLoading.js
+++ b/ui/src/Components/InteractiveLabeler/interactiveLabelerLoading.js
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export const MAP_READY_TIMEOUT_MS = 30000;
+
+export function formatBytes(bytes) {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "";
+  const units = ["B", "KB", "MB", "GB"];
+  const unitIndex = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(1024)),
+    units.length - 1
+  );
+  const value = bytes / 1024 ** unitIndex;
+  const decimalPlaces =
+    unitIndex === 2 ? 1 : unitIndex === 0 || value >= 10 ? 0 : 1;
+  return `${value.toFixed(decimalPlaces)} ${units[unitIndex]}`;
+}
+
+export function getLoadProgress(step, stepCount) {
+  if (!Number.isFinite(step) || !Number.isFinite(stepCount) || stepCount <= 0) {
+    return 0;
+  }
+  return Math.min(Math.max(step + 1, 0), stepCount) / stepCount;
+}
+
+function abortError() {
+  const error = new Error("Azure Maps initialization was cancelled.");
+  error.name = "AbortError";
+  return error;
+}
+
+export function waitForMapReady(
+  map,
+  { signal, timeoutMs = MAP_READY_TIMEOUT_MS, onReady } = {}
+) {
+  return new Promise((resolve, reject) => {
+    let timeoutId;
+
+    const cleanup = () => {
+      clearTimeout(timeoutId);
+      map.events.remove?.("ready", handleReady);
+      map.events.remove?.("error", handleError);
+      signal?.removeEventListener("abort", handleAbort);
+    };
+    const settle = (callback, value) => {
+      cleanup();
+      callback(value);
+    };
+    const handleReady = () => {
+      try {
+        onReady?.();
+        settle(resolve);
+      } catch (error) {
+        settle(reject, error);
+      }
+    };
+    const handleError = (event) => {
+      const message =
+        event?.error?.message || event?.message || "Azure Maps failed to load.";
+      settle(reject, new Error(message));
+    };
+    const handleAbort = () => settle(reject, abortError());
+
+    if (signal?.aborted) {
+      reject(abortError());
+      return;
+    }
+
+    map.events.add("ready", handleReady);
+    map.events.add("error", handleError);
+    signal?.addEventListener("abort", handleAbort, { once: true });
+    timeoutId = setTimeout(
+      () => settle(reject, new Error("Azure Maps timed out while loading.")),
+      timeoutMs
+    );
+  });
+}

--- a/ui/src/Components/InteractiveLabeler/interactiveLabelerLoading.js
+++ b/ui/src/Components/InteractiveLabeler/interactiveLabelerLoading.js
@@ -3,6 +3,16 @@
 
 export const MAP_READY_TIMEOUT_MS = 30000;
 
+// Progress is rendered by a component large enough that a per-chunk setState
+// is visible in a profile, so notifications are coalesced into this window.
+export const PROGRESS_THROTTLE_MS = 100;
+
+// Ceiling for a single artifact download. A declared length above this is
+// refused up front, and a response that arrives without a Content-Length is
+// abandoned once it crosses the same line, so a runaway stream cannot grow
+// until the tab dies.
+export const MAX_ARTIFACT_BYTES = 1024 * 1024 * 1024;
+
 export function formatBytes(bytes) {
   if (!Number.isFinite(bytes) || bytes <= 0) return "";
   const units = ["B", "KB", "MB", "GB"];
@@ -21,6 +31,112 @@ export function getLoadProgress(step, stepCount) {
     return 0;
   }
   return Math.min(Math.max(step + 1, 0), stepCount) / stepCount;
+}
+
+// Only a positive, exact integer is worth preallocating against — anything
+// else (absent, "", NaN, 1e21) falls back to chunk accumulation.
+export function parseContentLength(value) {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+// Coalesce download notifications so a multi-megabyte artifact cannot fire a
+// state update per response chunk. `flush` bypasses the window so the final
+// byte count is always reported, even when the last chunk lands mid-window.
+export function createProgressThrottle(onProgress, options = {}) {
+  const { throttleMs = PROGRESS_THROTTLE_MS, now = Date.now } = options;
+  let lastEmitAt = -Infinity;
+  let lastLoaded = null;
+
+  const emit = (loaded, total) => {
+    lastEmitAt = now();
+    lastLoaded = loaded;
+    onProgress(loaded, total);
+  };
+
+  return {
+    report(loaded, total) {
+      if (!onProgress || now() - lastEmitAt < throttleMs) return;
+      emit(loaded, total);
+    },
+    flush(loaded, total) {
+      if (!onProgress || lastLoaded === loaded) return;
+      emit(loaded, total);
+    },
+  };
+}
+
+// Read a response body fully into one ArrayBuffer. When the response declares
+// a usable Content-Length each chunk is written straight into its final
+// home, so peak memory stays at a single copy of the artifact rather than the
+// chunk list plus the consolidated buffer.
+export async function readResponseBuffer(response, onProgress, options = {}) {
+  const { maxBytes = MAX_ARTIFACT_BYTES } = options;
+  const total = parseContentLength(response.headers?.get?.("content-length"));
+  const progress = createProgressThrottle(onProgress, options);
+
+  if (total !== null && total > maxBytes) {
+    throw new Error(
+      `Artifact is ${formatBytes(total)}, above the ` +
+        `${formatBytes(maxBytes)} download limit.`
+    );
+  }
+
+  if (!response.body) {
+    const buffer = await response.arrayBuffer();
+    progress.flush(buffer.byteLength, total ?? buffer.byteLength);
+    return buffer;
+  }
+
+  const reader = response.body.getReader();
+  let bytes = total !== null ? new Uint8Array(total) : null;
+  const chunks = bytes ? null : [];
+  let loaded = 0;
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    const next = loaded + value.byteLength;
+    if (next > maxBytes) {
+      throw new Error(
+        `Artifact exceeded the ${formatBytes(maxBytes)} download limit.`
+      );
+    }
+
+    if (bytes) {
+      // The body outran its declared length. Grow once instead of silently
+      // truncating the archive.
+      if (next > bytes.length) {
+        const grown = new Uint8Array(next);
+        grown.set(bytes.subarray(0, loaded));
+        bytes = grown;
+      }
+      bytes.set(value, loaded);
+    } else {
+      chunks.push(value);
+    }
+
+    loaded = next;
+    progress.report(loaded, total);
+  }
+
+  progress.flush(loaded, total);
+
+  if (bytes) {
+    // A body shorter than its declared length leaves a zero-filled tail.
+    return loaded === bytes.length
+      ? bytes.buffer
+      : bytes.buffer.slice(0, loaded);
+  }
+
+  const merged = new Uint8Array(loaded);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return merged.buffer;
 }
 
 function abortError() {

--- a/ui/src/Components/InteractiveLabeler/interactiveLabelerLoading.test.js
+++ b/ui/src/Components/InteractiveLabeler/interactiveLabelerLoading.test.js
@@ -2,10 +2,56 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  createProgressThrottle,
   formatBytes,
   getLoadProgress,
+  parseContentLength,
+  readResponseBuffer,
   waitForMapReady,
 } from "./interactiveLabelerLoading.js";
+
+// Deterministic stand-in for a streamed fetch response. `msPerChunk` advances
+// the injected clock on every read so throttling can be asserted without
+// real timers.
+function createStreamedResponse(chunks, options = {}) {
+  const { contentLength, clock, msPerChunk = 0 } = options;
+  let index = 0;
+  return {
+    headers: {
+      get: (name) =>
+        name === "content-length" && contentLength !== undefined
+          ? String(contentLength)
+          : null,
+    },
+    body: {
+      getReader: () => ({
+        read: async () => {
+          if (clock) clock.now += msPerChunk;
+          if (index >= chunks.length) return { done: true, value: undefined };
+          return { done: false, value: chunks[index++] };
+        },
+      }),
+    },
+  };
+}
+
+function createChunks(count, size, seed = 1) {
+  return Array.from(
+    { length: count },
+    (_, i) => new Uint8Array(size).fill((seed + i) % 256)
+  );
+}
+
+function concatChunks(chunks) {
+  const total = chunks.reduce((sum, c) => sum + c.byteLength, 0);
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return merged;
+}
 
 function createMapEvents() {
   const handlers = new Map();
@@ -84,4 +130,183 @@ test("waitForMapReady rejects when initialization is aborted", async () => {
   await assert.rejects(result, { name: "AbortError" });
   assert.equal(events.has("ready"), false);
   assert.equal(events.has("error"), false);
+});
+test("parseContentLength accepts positive integers and rejects the rest", () => {
+  assert.equal(parseContentLength("1024"), 1024);
+  assert.equal(parseContentLength(null), null);
+  assert.equal(parseContentLength(""), null);
+  assert.equal(parseContentLength("not-a-number"), null);
+  assert.equal(parseContentLength("0"), null);
+  assert.equal(parseContentLength("-5"), null);
+  assert.equal(parseContentLength("1e21"), null);
+});
+
+test("createProgressThrottle coalesces reports inside the window", () => {
+  const clock = { now: 0 };
+  const calls = [];
+  const throttle = createProgressThrottle((loaded) => calls.push(loaded), {
+    throttleMs: 100,
+    now: () => clock.now,
+  });
+
+  throttle.report(10, 100);
+  throttle.report(20, 100);
+  throttle.report(30, 100);
+
+  assert.deepEqual(calls, [10]);
+});
+
+test("createProgressThrottle emits again once the window elapses", () => {
+  const clock = { now: 0 };
+  const calls = [];
+  const throttle = createProgressThrottle((loaded) => calls.push(loaded), {
+    throttleMs: 100,
+    now: () => clock.now,
+  });
+
+  throttle.report(10, 100);
+  clock.now = 150;
+  throttle.report(20, 100);
+
+  assert.deepEqual(calls, [10, 20]);
+});
+
+test("createProgressThrottle flushes the final count but never duplicates it", () => {
+  const clock = { now: 0 };
+  const calls = [];
+  const throttle = createProgressThrottle((loaded) => calls.push(loaded), {
+    throttleMs: 100,
+    now: () => clock.now,
+  });
+
+  throttle.report(10, 100);
+  throttle.report(100, 100);
+  throttle.flush(100, 100);
+  throttle.flush(100, 100);
+
+  assert.deepEqual(calls, [10, 100]);
+});
+
+test("readResponseBuffer throttles progress but always reports the total", async () => {
+  const clock = { now: 0 };
+  const chunks = createChunks(50, 1024);
+  const contentLength = 50 * 1024;
+  const calls = [];
+  const response = createStreamedResponse(chunks, {
+    contentLength,
+    clock,
+    msPerChunk: 0,
+  });
+
+  const buffer = await readResponseBuffer(
+    response,
+    (loaded, total) => calls.push([loaded, total]),
+    { throttleMs: 100, now: () => clock.now }
+  );
+
+  assert.equal(buffer.byteLength, contentLength);
+  assert.ok(
+    calls.length < chunks.length,
+    `expected fewer than ${chunks.length} notifications, got ${calls.length}`
+  );
+  assert.deepEqual(calls.at(-1), [contentLength, contentLength]);
+});
+
+test("readResponseBuffer notifies per chunk when each read outlasts the window", async () => {
+  const clock = { now: 0 };
+  const chunks = createChunks(5, 16);
+  const calls = [];
+  const response = createStreamedResponse(chunks, {
+    contentLength: 5 * 16,
+    clock,
+    msPerChunk: 200,
+  });
+
+  await readResponseBuffer(response, (loaded) => calls.push(loaded), {
+    throttleMs: 100,
+    now: () => clock.now,
+  });
+
+  assert.deepEqual(calls, [16, 32, 48, 64, 80]);
+});
+
+test("readResponseBuffer preallocates from Content-Length and preserves bytes", async () => {
+  const chunks = createChunks(8, 32, 7);
+  const expected = concatChunks(chunks);
+  const response = createStreamedResponse(chunks, {
+    contentLength: expected.byteLength,
+  });
+
+  const buffer = await readResponseBuffer(response, null);
+
+  assert.equal(buffer.byteLength, expected.byteLength);
+  assert.deepEqual(new Uint8Array(buffer), expected);
+});
+
+test("readResponseBuffer falls back to accumulation without a Content-Length", async () => {
+  const chunks = createChunks(4, 64, 3);
+  const expected = concatChunks(chunks);
+  const response = createStreamedResponse(chunks);
+
+  const buffer = await readResponseBuffer(response, null);
+
+  assert.deepEqual(new Uint8Array(buffer), expected);
+});
+
+test("readResponseBuffer rejects a declared length above the cap", async () => {
+  const response = createStreamedResponse(createChunks(1, 8), {
+    contentLength: 4096,
+  });
+
+  await assert.rejects(
+    readResponseBuffer(response, null, { maxBytes: 1024 }),
+    /above the .* download limit/
+  );
+});
+
+test("readResponseBuffer bounds an unknown-length body at the cap", async () => {
+  const response = createStreamedResponse(createChunks(10, 512));
+
+  await assert.rejects(
+    readResponseBuffer(response, null, { maxBytes: 1024 }),
+    /exceeded the .* download limit/
+  );
+});
+
+test("readResponseBuffer keeps every byte when the body outruns Content-Length", async () => {
+  const chunks = createChunks(4, 100, 11);
+  const expected = concatChunks(chunks);
+  const response = createStreamedResponse(chunks, { contentLength: 250 });
+
+  const buffer = await readResponseBuffer(response, null);
+
+  assert.equal(buffer.byteLength, 400);
+  assert.deepEqual(new Uint8Array(buffer), expected);
+});
+
+test("readResponseBuffer trims the tail when the body is shorter than declared", async () => {
+  const chunks = createChunks(2, 50, 5);
+  const expected = concatChunks(chunks);
+  const response = createStreamedResponse(chunks, { contentLength: 500 });
+
+  const buffer = await readResponseBuffer(response, null);
+
+  assert.equal(buffer.byteLength, 100);
+  assert.deepEqual(new Uint8Array(buffer), expected);
+});
+
+test("readResponseBuffer handles a response without a readable body", async () => {
+  const expected = createChunks(1, 24, 9)[0];
+  const calls = [];
+  const response = {
+    headers: { get: () => null },
+    arrayBuffer: async () => expected.buffer,
+  };
+
+  const buffer = await readResponseBuffer(response, (loaded, total) =>
+    calls.push([loaded, total])
+  );
+
+  assert.deepEqual(new Uint8Array(buffer), expected);
+  assert.deepEqual(calls, [[24, 24]]);
 });

--- a/ui/src/Components/InteractiveLabeler/interactiveLabelerLoading.test.js
+++ b/ui/src/Components/InteractiveLabeler/interactiveLabelerLoading.test.js
@@ -1,0 +1,87 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  formatBytes,
+  getLoadProgress,
+  waitForMapReady,
+} from "./interactiveLabelerLoading.js";
+
+function createMapEvents() {
+  const handlers = new Map();
+  return {
+    add(name, handler) {
+      handlers.set(name, handler);
+    },
+    remove(name, handler) {
+      if (handlers.get(name) === handler) handlers.delete(name);
+    },
+    emit(name, event) {
+      handlers.get(name)?.(event);
+    },
+    has(name) {
+      return handlers.has(name);
+    },
+  };
+}
+
+test("formatBytes keeps one decimal for megabytes", () => {
+  assert.equal(formatBytes(31 * 1024 * 1024), "31.0 MB");
+  assert.equal(formatBytes(330 * 1024 * 1024), "330.0 MB");
+});
+
+test("getLoadProgress reaches one on the final step", () => {
+  assert.equal(getLoadProgress(0, 6), 1 / 6);
+  assert.equal(getLoadProgress(5, 6), 1);
+});
+
+test("waitForMapReady resolves and removes listeners on ready", async () => {
+  const events = createMapEvents();
+  let readyCalls = 0;
+  const result = waitForMapReady(
+    { events },
+    { timeoutMs: 100, onReady: () => readyCalls++ }
+  );
+
+  events.emit("ready");
+  await result;
+
+  assert.equal(readyCalls, 1);
+  assert.equal(events.has("ready"), false);
+  assert.equal(events.has("error"), false);
+});
+
+test("waitForMapReady rejects an Azure Maps error", async () => {
+  const events = createMapEvents();
+  const result = waitForMapReady({ events }, { timeoutMs: 100 });
+
+  events.emit("error", { error: new Error("authentication failed") });
+
+  await assert.rejects(result, /authentication failed/);
+});
+
+test("waitForMapReady rejects when loading times out", async () => {
+  const events = createMapEvents();
+
+  await assert.rejects(
+    waitForMapReady({ events }, { timeoutMs: 1 }),
+    /timed out/
+  );
+  assert.equal(events.has("ready"), false);
+  assert.equal(events.has("error"), false);
+});
+
+test("waitForMapReady rejects when initialization is aborted", async () => {
+  const events = createMapEvents();
+  const controller = new AbortController();
+  const result = waitForMapReady(
+    { events },
+    { signal: controller.signal, timeoutMs: 100 }
+  );
+
+  controller.abort();
+
+  await assert.rejects(result, { name: "AbortError" });
+  assert.equal(events.has("ready"), false);
+  assert.equal(events.has("error"), false);
+});

--- a/ui/src/Components/KeyboardShortcutHelp.jsx
+++ b/ui/src/Components/KeyboardShortcutHelp.jsx
@@ -83,9 +83,10 @@ const useStyles = makeStyles({
 const KeyboardShortcutHelp = ({
   shortcuts,
   title = "Keyboard shortcuts",
+  defaultExpanded = true,
 }) => {
   const styles = useStyles();
-  const [isExpanded, setIsExpanded] = useState(true);
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
 
   return (
     <section className={styles.root} aria-label={title}>
@@ -141,6 +142,7 @@ KeyboardShortcutHelp.propTypes = {
     })
   ).isRequired,
   title: PropTypes.string,
+  defaultExpanded: PropTypes.bool,
 };
 
 export default KeyboardShortcutHelp;

--- a/ui/src/Components/guidedTourLayout.js
+++ b/ui/src/Components/guidedTourLayout.js
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export function getTourCardStyle(spot, viewportWidth, viewportHeight) {
+  const viewportMargin = 16;
+  const cardGap = 14;
+  const preferredCardHeight = 280;
+  const cardWidth = Math.min(340, viewportWidth - viewportMargin * 2);
+  const targetBottom = spot.top + spot.height;
+  const spaceBelow =
+    viewportHeight - targetBottom - cardGap - viewportMargin;
+  const spaceAbove = spot.top - cardGap - viewportMargin;
+  const style = {
+    position: "fixed",
+    width: cardWidth,
+    left: Math.max(
+      viewportMargin,
+      Math.min(spot.left - 8, viewportWidth - cardWidth - viewportMargin)
+    ),
+  };
+
+  if (spaceBelow >= preferredCardHeight) {
+    style.top = targetBottom + cardGap;
+    style.maxHeight = viewportHeight - style.top - viewportMargin;
+  } else if (spaceAbove >= preferredCardHeight) {
+    style.bottom = viewportHeight - spot.top + cardGap;
+    style.maxHeight = spaceAbove;
+  } else {
+    style.top = Math.max(
+      viewportMargin,
+      Math.min(
+        spot.top + cardGap,
+        viewportHeight - preferredCardHeight - viewportMargin
+      )
+    );
+    style.maxHeight = viewportHeight - style.top - viewportMargin;
+  }
+
+  return style;
+}

--- a/ui/src/Components/guidedTourLayout.test.js
+++ b/ui/src/Components/guidedTourLayout.test.js
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { getTourCardStyle } from "./guidedTourLayout.js";
+
+test("getTourCardStyle keeps a card visible for a viewport-sized target", () => {
+  const viewportHeight = 768;
+  const style = getTourCardStyle(
+    { top: 60, left: 0, width: 1200, height: 690 },
+    1280,
+    viewportHeight
+  );
+
+  assert.ok(style.top >= 16);
+  assert.ok(style.top + style.maxHeight <= viewportHeight - 16);
+});
+
+test("getTourCardStyle places a card below a small target when space exists", () => {
+  const style = getTourCardStyle(
+    { top: 40, left: 100, width: 120, height: 40 },
+    1280,
+    768
+  );
+
+  assert.equal(style.top, 94);
+  assert.equal(style.bottom, undefined);
+});

--- a/ui/src/assets/css/style.css
+++ b/ui/src/assets/css/style.css
@@ -693,6 +693,7 @@ body {
 }
 
 .tour-card {
+  box-sizing: border-box;
   pointer-events: auto;
   background: #ffffff;
   border: 1px solid #e1dfdd;
@@ -700,6 +701,7 @@ body {
   box-shadow: 0 8px 24px rgba(15, 23, 42, 0.18);
   padding: 16px;
   z-index: 100001;
+  overflow-y: auto;
 }
 
 .tour-card-fixed {


### PR DESCRIPTION
## Description

Improves the Interactive Labeler startup experience with staged loading progress, clearer artifact download feedback, guided onboarding, and recoverable initialization errors.

### Changes

- Added a dedicated staged loading component.
- Added artifact download progress in decimal MB.
- Updated the progress bar to reach 100% on the final stage.
- Added an Interactive Labeler guided tour.
- Kept guided-tour cards within the visible viewport.
- Configured the keyboard shortcuts panel to start collapsed.
- Added error, timeout, and cancellation handling for Azure Maps initialization.
- Added recovery actions when initialization fails.
- Disposed partially initialized maps after failures or unmounting.
- Added focused tests for loading behavior and guided-tour positioning.

Fixes # <!-- issue number, if applicable -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Infrastructure / CI change

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My changes follow the project's coding standards (PEP 8 for Python, ESLint rules for JS/TS)
- [x] I have added or updated tests that cover my changes
- [ ] Python tests pass locally (`cd hastelib && hatch run test:pytest`) and the UI lints clean (`cd ui && npm run lint`)
- [ ] I have updated the relevant documentation (README, docs/, inline comments)
- [ ] I have added an entry to [CHANGELOG.md](../CHANGELOG.md) if this is a user-facing change

## Testing

### Focused tests

```bash
cd ui
npm run test:interactive-labeler