### PR TITLE
fix(training): support BigTIFF training rasters

### DIFF
--- a/docker/training/code/create_masks.py
+++ b/docker/training/code/create_masks.py
@@ -119,6 +119,28 @@ def _run(command: List[str], what: str) -> None:
         )
 
 
+def write_training_raster(
+    output_fn: str,
+    data: np.ndarray,
+    profile: dict,
+    band: Optional[int] = None,
+) -> None:
+    """Write a training raster without the classic TIFF 4 GiB limit.
+
+    ``Dataset.profile`` does not retain the source dataset's BigTIFF creation
+    option. Apply it to every derived image and mask while allowing GDAL to
+    keep small outputs as classic TIFFs.
+    """
+    output_profile = profile.copy()
+    output_profile["BIGTIFF"] = "IF_SAFER"
+
+    with rasterio.open(output_fn, "w", **output_profile) as output:
+        if band is None:
+            output.write(data)
+        else:
+            output.write(data, band)
+
+
 def get_class_names_from_labels(labels_fn: str, key: str = "class") -> set:
     """Get the class names from a GeoJSON file.
 
@@ -481,8 +503,7 @@ def create_mask_for_labels(
     profile["count"] = data.shape[0]
     profile["transform"] = transform
     profile["predictor"] = 2
-    with rasterio.open(output_cropped_image_fn, "w", **profile) as f:
-        f.write(data)
+    write_training_raster(output_cropped_image_fn, data, profile)
 
     ##########
     # Create mask
@@ -579,8 +600,7 @@ def create_mask_for_labels(
         background_mask = (transform > 0) & (transform < buffer_in_meters)
         mask[background_mask] = class_name_to_idx_map[class_to_buffer_by]
 
-    with rasterio.open(output_buffered_mask_fn, "w", **mask_profile) as f:
-        f.write(mask, 1)
+    write_training_raster(output_buffered_mask_fn, mask, mask_profile, band=1)
 
     ##########
     # Check that the buffered mask and the cropped image have the same dimensions

--- a/docker/training/code/inference.py
+++ b/docker/training/code/inference.py
@@ -217,6 +217,7 @@ def main() -> None:
     profile["blockysize"] = 512
     profile["tiled"] = True
     profile["interleave"] = "pixel"
+    profile["BIGTIFF"] = "IF_SAFER"
 
     with rasterio.open(output_fn, "w", **profile) as f:
         f.write(output, 1)

--- a/docker/training/code/output2visualizer.py
+++ b/docker/training/code/output2visualizer.py
@@ -101,6 +101,7 @@ def main(args):
 
     profile["count"] = 4
     profile["nodata"] = 0
+    profile["BIGTIFF"] = "IF_SAFER"
 
     with rasterio.open(args.output_fn, "w", **profile) as f:
         f.colorinterp = [

--- a/docker/training/code/tests/test_create_masks_writes.py
+++ b/docker/training/code/tests/test_create_masks_writes.py
@@ -74,6 +74,41 @@ def _get_training_raster_calls():
     ]
 
 
+def _get_bigtiff_assignment_and_write_lines(filename):
+    """Find the BigTIFF profile assignment and rasterio write calls."""
+    path = os.path.join(CODE_DIR, filename)
+    with open(path) as source_file:
+        tree = ast.parse(source_file.read())
+
+    assignments = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Subscript)
+            and isinstance(target.value, ast.Name)
+            and target.value.id == "profile"
+            and target.slice.value == "BIGTIFF"
+            for target in node.targets
+        )
+        and node.value.value == "IF_SAFER"
+    ]
+    write_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "rasterio"
+        and node.func.attr == "open"
+        and any(
+            isinstance(argument, ast.Constant) and argument.value == "w"
+            for argument in node.args
+        )
+    ]
+    return assignments, write_calls
+
+
 class TestWriteTrainingRaster(unittest.TestCase):
     def setUp(self):
         self.rasterio = _FakeRasterio()
@@ -146,6 +181,48 @@ class TestCreateMaskWritePaths(unittest.TestCase):
         self.assertEqual(len(mask_call.keywords), 1)
         self.assertEqual(mask_call.keywords[0].arg, "band")
         self.assertEqual(mask_call.keywords[0].value.value, 1)
+
+
+class TestWorkflowBigTiffProfiles(unittest.TestCase):
+    def _assert_bigtiff_precedes_raster_write(self, filename):
+        assignments, write_calls = _get_bigtiff_assignment_and_write_lines(
+            filename
+        )
+
+        self.assertEqual(len(assignments), 1)
+        self.assertEqual(len(write_calls), 1)
+        self.assertLess(assignments[0].lineno, write_calls[0].lineno)
+
+    def test_inference_predictions_use_if_safer(self):
+        self._assert_bigtiff_precedes_raster_write("inference.py")
+
+    def test_visualizer_output_uses_if_safer(self):
+        self._assert_bigtiff_precedes_raster_write("output2visualizer.py")
+
+    def test_raw_mask_rasterizer_uses_bigtiff(self):
+        with open(CREATE_MASKS_PATH) as source_file:
+            tree = ast.parse(source_file.read())
+
+        rasterize_commands = [
+            node.value
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Assign)
+            and isinstance(node.value, ast.List)
+            and node.value.elts
+            and isinstance(node.value.elts[0], ast.Constant)
+            and node.value.elts[0].value == "gdal_rasterize"
+        ]
+
+        self.assertTrue(
+            any(
+                any(
+                    isinstance(argument, ast.Constant)
+                    and argument.value == "BIGTIFF=YES"
+                    for argument in command.elts
+                )
+                for command in rasterize_commands
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/docker/training/code/tests/test_create_masks_writes.py
+++ b/docker/training/code/tests/test_create_masks_writes.py
@@ -1,0 +1,152 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Tests for BigTIFF-safe raster writes in ``create_masks.py``."""
+
+import ast
+import os
+import unittest
+from typing import Optional
+
+import numpy as np
+
+CODE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CREATE_MASKS_PATH = os.path.join(CODE_DIR, "create_masks.py")
+
+
+class _FakeWriter:
+    def __init__(self):
+        self.write_calls = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+    def write(self, *args):
+        self.write_calls.append(args)
+
+
+class _FakeRasterio:
+    def __init__(self):
+        self.open_calls = []
+        self.writer = _FakeWriter()
+
+    def open(self, *args, **kwargs):
+        self.open_calls.append((args, kwargs))
+        return self.writer
+
+
+def _load_write_training_raster(rasterio_module):
+    """Load the writer without importing create_masks' GDAL dependencies."""
+    with open(CREATE_MASKS_PATH) as source_file:
+        source = source_file.read()
+
+    start = source.index("def write_training_raster(")
+    end = source.index("def get_class_names_from_labels(")
+    namespace = {
+        "np": np,
+        "Optional": Optional,
+        "rasterio": rasterio_module,
+    }
+    exec(compile(source[start:end], CREATE_MASKS_PATH, "exec"), namespace)
+    return namespace["write_training_raster"]
+
+
+def _get_training_raster_calls():
+    """Find helper calls inside ``create_mask_for_labels``."""
+    with open(CREATE_MASKS_PATH) as source_file:
+        tree = ast.parse(source_file.read())
+
+    create_masks = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "create_mask_for_labels"
+    )
+    return [
+        node
+        for node in ast.walk(create_masks)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "write_training_raster"
+    ]
+
+
+class TestWriteTrainingRaster(unittest.TestCase):
+    def setUp(self):
+        self.rasterio = _FakeRasterio()
+        self.write_training_raster = _load_write_training_raster(self.rasterio)
+
+    def test_applies_if_safer_without_mutating_input_profile(self):
+        profile = {
+            "driver": "GTiff",
+            "compress": "lzw",
+            "BIGTIFF": "NO",
+        }
+        data = np.zeros((3, 2, 2), dtype=np.uint8)
+
+        self.write_training_raster("image.tif", data, profile)
+
+        args, output_profile = self.rasterio.open_calls[0]
+        self.assertEqual(args, ("image.tif", "w"))
+        self.assertEqual(output_profile["BIGTIFF"], "IF_SAFER")
+        self.assertEqual(output_profile["compress"], "lzw")
+        self.assertEqual(profile["BIGTIFF"], "NO")
+
+    def test_writes_multiband_image_without_band_index(self):
+        data = np.zeros((3, 2, 2), dtype=np.uint8)
+
+        self.write_training_raster("image.tif", data, {"driver": "GTiff"})
+
+        self.assertEqual(self.rasterio.writer.write_calls, [(data,)])
+
+    def test_writes_mask_to_requested_band(self):
+        mask = np.zeros((2, 2), dtype=np.uint8)
+
+        self.write_training_raster(
+            "mask.tif", mask, {"driver": "GTiff"}, band=1
+        )
+
+        self.assertEqual(self.rasterio.writer.write_calls, [(mask, 1)])
+
+
+class TestCreateMaskWritePaths(unittest.TestCase):
+    def test_cropped_image_uses_bigtiff_writer(self):
+        calls = _get_training_raster_calls()
+
+        image_call = next(
+            call
+            for call in calls
+            if isinstance(call.args[0], ast.Name)
+            and call.args[0].id == "output_cropped_image_fn"
+        )
+
+        self.assertEqual(
+            [argument.id for argument in image_call.args],
+            ["output_cropped_image_fn", "data", "profile"],
+        )
+        self.assertEqual(image_call.keywords, [])
+
+    def test_buffered_mask_uses_bigtiff_writer(self):
+        calls = _get_training_raster_calls()
+
+        mask_call = next(
+            call
+            for call in calls
+            if isinstance(call.args[0], ast.Name)
+            and call.args[0].id == "output_buffered_mask_fn"
+        )
+
+        self.assertEqual(
+            [argument.id for argument in mask_call.args],
+            ["output_buffered_mask_fn", "mask", "mask_profile"],
+        )
+        self.assertEqual(len(mask_call.keywords), 1)
+        self.assertEqual(mask_call.keywords[0].arg, "band")
+        self.assertEqual(mask_call.keywords[0].value.value, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/spec/features/training-workflow-sync/README.md
+++ b/spec/features/training-workflow-sync/README.md
@@ -35,6 +35,9 @@ on GDAL reprojecting on the fly.
   observed in dev.
 - **Training was dataloader-bound.** Patch reads from compressed GeoTIFFs left
   the GPU at roughly half utilization.
+- **Large aerial scenes exceeded classic TIFF limits.** Derived training
+  images inherited the source profile without a BigTIFF creation option, so
+  crops larger than 4 GiB failed during `create_masks.py`.
 
 Without this, a project defining a **No Damage** class trains against a
 silently wrong objective, and its damage reports cannot be trusted.
@@ -47,6 +50,8 @@ silently wrong objective, and its damage reports cannot be trusted.
 - [x] Clustering is opt-in and leaves the previous single-pair output
       byte-identical when unset
 - [x] Every mask class is rasterized in the imagery CRS
+- [x] Derived training images and masks select BigTIFF when their size may
+      exceed the classic TIFF limit
 - [ ] A dev retraining run confirms the above end-to-end *(outstanding — see
       [test-plan.md](test-plan.md))*
 
@@ -95,3 +100,4 @@ of step. See [rollout.md](rollout.md).
 | 2026-08-21 | Give "No Damage" no output channel at all | Penalizing its probability only made it unattractive; removing the channel makes it unrepresentable |
 | 2026-08-21 | Choose training precision at runtime | HASTE's Batch pools are heterogeneous — T4s have no bf16 — so `bf16-mixed` cannot be hardcoded as upstream does |
 | 2026-08-21 | Keep `log_dict(train_metrics)` where upstream dropped it | `hastegeo`'s `tbparser` reads `train_MulticlassAccuracy` out of the TensorBoard events |
+| 2026-08-26 | Use `BIGTIFF=IF_SAFER` for rasterio-generated training artifacts | `YES` changes every small output; `IF_SAFER` keeps classic TIFFs when safe and prevents the observed 4 GiB write failure |

--- a/spec/features/training-workflow-sync/README.md
+++ b/spec/features/training-workflow-sync/README.md
@@ -50,8 +50,8 @@ silently wrong objective, and its damage reports cannot be trusted.
 - [x] Clustering is opt-in and leaves the previous single-pair output
       byte-identical when unset
 - [x] Every mask class is rasterized in the imagery CRS
-- [x] Derived training images and masks select BigTIFF when their size may
-      exceed the classic TIFF limit
+- [x] Derived training images, masks, predictions, and visualizer rasters
+      select BigTIFF when their size may exceed the classic TIFF limit
 - [ ] A dev retraining run confirms the above end-to-end *(outstanding — see
       [test-plan.md](test-plan.md))*
 

--- a/spec/features/training-workflow-sync/design.md
+++ b/spec/features/training-workflow-sync/design.md
@@ -170,10 +170,12 @@ The cropped training image and buffered mask can exceed the classic TIFF
 source dataset's BigTIFF creation option, so derived writes must apply it
 explicitly.
 
-Both rasterio write paths go through one helper that copies the source
-profile and sets `BIGTIFF=IF_SAFER`. Copying avoids mutating a profile that a
-caller may reuse. `IF_SAFER` lets GDAL retain classic TIFF for small outputs
-while selecting BigTIFF when the uncompressed result could exceed 4 GiB.
+The two `create_masks.py` rasterio write paths go through one helper that
+copies the source profile and sets `BIGTIFF=IF_SAFER`. Copying avoids
+mutating a profile that a caller may reuse. The inference prediction and
+visualizer writers also set `BIGTIFF=IF_SAFER` before opening their outputs.
+`IF_SAFER` lets GDAL retain classic TIFF for small outputs while selecting
+BigTIFF when the uncompressed result could exceed 4 GiB.
 
 The raw mask is created by `gdal_rasterize` and already uses
 `BIGTIFF=YES`. This change aligns the surrounding rasterio writes without

--- a/spec/features/training-workflow-sync/design.md
+++ b/spec/features/training-workflow-sync/design.md
@@ -161,3 +161,20 @@ carries matching `gt`/`ge` constraints for the API path.
 | `assert subprocess.call(...) == 0` | `subprocess.run` with captured stderr | Pre-existing HASTE hardening |
 | Broad `except ValueError` on the cluster skip | `CropGeometryOutsideRasterError` | Not swallowing real errors per cluster |
 | `configure_losses()` override | Not ported | Adds a `dice` branch this repo never uses; `torchgeo` is pinned here and unpinned upstream |
+
+## 7. Large raster outputs
+
+The cropped training image and buffered mask can exceed the classic TIFF
+4 GiB limit when labels span a large, high-resolution aerial scene.
+`rasterio.DatasetReader.profile` preserves raster metadata but not the
+source dataset's BigTIFF creation option, so derived writes must apply it
+explicitly.
+
+Both rasterio write paths go through one helper that copies the source
+profile and sets `BIGTIFF=IF_SAFER`. Copying avoids mutating a profile that a
+caller may reuse. `IF_SAFER` lets GDAL retain classic TIFF for small outputs
+while selecting BigTIFF when the uncompressed result could exceed 4 GiB.
+
+The raw mask is created by `gdal_rasterize` and already uses
+`BIGTIFF=YES`. This change aligns the surrounding rasterio writes without
+changing CRS, transform, dimensions, compression, tiling, nodata, or dtype.

--- a/spec/features/training-workflow-sync/rollout.md
+++ b/spec/features/training-workflow-sync/rollout.md
@@ -11,6 +11,9 @@ training image**.
 | `docker/training/code/**` | `docker-build-and-push.yml` (triggers on that path) | training image, pinned by `AZURE_BATCH_DOCKER_IMAGE` | Batch tasks |
 | `hastelib/**` | `deploy-apps.yml` | `hastegeo` wheel | `hastefuncapi`, `hastefuncqueues` |
 
+The BigTIFF correction touches only `docker/training/code/**`. It requires a
+new training image but no `hastegeo` wheel or Function App deployment.
+
 Config generation runs in **`hastefuncqueues`**, not `hastefuncapi` — a deploy
 covering only the API app changes nothing.
 

--- a/spec/features/training-workflow-sync/test-plan.md
+++ b/spec/features/training-workflow-sync/test-plan.md
@@ -2,9 +2,9 @@
 
 ## Coverage
 
-**87 tests.** Container-side tests live in `docker/training/code/tests/` and run
-without the conda env unless noted; `hastegeo` tests follow the repo's usual
-layout.
+**92 container-side tests, plus 16 `hastegeo` tests.** Container-side tests
+live in `docker/training/code/tests/` and run without the conda env unless
+noted; `hastegeo` tests follow the repo's usual layout.
 
 ```bash
 cd docker/training/code && python -m unittest discover -s tests -t .
@@ -19,6 +19,7 @@ PYTHONPATH=$PWD/hastelib/src python -m unittest \
 | `tests/test_create_masks.py` | 13 | Grid assignment, STRtree/brute-force equivalence, CRS gate, extent clipping, skip-path exception type |
 | `tests/test_datasets.py` | 10 | Channel clipping, too-few-bands rejection, preload equivalence and aliasing |
 | `tests/test_create_masks_cleanup.py` | 9 | Stale and partial output removal, prefix safety |
+| `tests/test_create_masks_writes.py` | 5 | BigTIFF option, profile immutability, both write forms, and production call-site wiring |
 | `hastelib/tests/core/utils/test_label_classes.py` | 16 | The auto-enable decision across class layouts and spellings |
 
 ## Load-bearing tests
@@ -35,6 +36,7 @@ each was **verified to fail against the code it replaced**:
 | `test_matches_a_brute_force_scan` | The STRtree selects exactly what the scan it replaced did |
 | `test_patches_are_identical_to_the_disk_path` | Preload is a speed-up; any difference in what it returns is a bug |
 | `test_is_distinct_from_valueerror` | The cluster skip path cannot swallow a config error |
+| `test_applies_if_safer_without_mutating_input_profile` | Both derived raster paths can exceed 4 GiB, and the source profile remains reusable |
 
 ## Method notes
 
@@ -64,6 +66,10 @@ for a config the container rejects.
       not reproduce on GDAL 3.4.1. Decisive check: pull an existing
       experiment's `masks/` artifact and look for any value above 1. If it is
       all `{0, 1}`, every multi-class model trained here saw background only.
+- [ ] **Affected-layer retraining with a BigTIFF image.** Unit tests pin the
+      GDAL creation option without allocating a 4+ GiB array. Re-run the
+      Buenaventura layer after deploying the patched training image to verify
+      the production-sized path.
 
 ## CI gap
 

--- a/spec/features/training-workflow-sync/test-plan.md
+++ b/spec/features/training-workflow-sync/test-plan.md
@@ -2,7 +2,7 @@
 
 ## Coverage
 
-**92 container-side tests, plus 16 `hastegeo` tests.** Container-side tests
+**95 container-side tests, plus 16 `hastegeo` tests.** Container-side tests
 live in `docker/training/code/tests/` and run without the conda env unless
 noted; `hastegeo` tests follow the repo's usual layout.
 
@@ -19,7 +19,7 @@ PYTHONPATH=$PWD/hastelib/src python -m unittest \
 | `tests/test_create_masks.py` | 13 | Grid assignment, STRtree/brute-force equivalence, CRS gate, extent clipping, skip-path exception type |
 | `tests/test_datasets.py` | 10 | Channel clipping, too-few-bands rejection, preload equivalence and aliasing |
 | `tests/test_create_masks_cleanup.py` | 9 | Stale and partial output removal, prefix safety |
-| `tests/test_create_masks_writes.py` | 5 | BigTIFF option, profile immutability, both write forms, and production call-site wiring |
+| `tests/test_create_masks_writes.py` | 8 | BigTIFF option, profile immutability, all production write paths, and raw-mask rasterization |
 | `hastelib/tests/core/utils/test_label_classes.py` | 16 | The auto-enable decision across class layouts and spellings |
 
 ## Load-bearing tests


### PR DESCRIPTION
## Summary

Prevent the training workflow from failing when derived rasters exceed the classic TIFF 4 GiB limit. Rasterio-generated crops, masks, predictions, and visualizer intermediates now use `BIGTIFF=IF_SAFER`, preserving classic TIFF output for smaller files while allowing large aerial products to use BigTIFF. The raw `gdal_rasterize` mask path already uses `BIGTIFF=YES`.

## Changes

- add one shared raster writer that copies the source profile and applies `BIGTIFF=IF_SAFER` to cropped images and buffered masks
- apply `BIGTIFF=IF_SAFER` to inference predictions and visualizer intermediates before their rasterio writes
- add eight regression tests covering profile safety, both rasterio write forms, all production call sites, and the raw-mask GDAL creation option
- document the output-size contract and training-image-only rollout in the existing training workflow spec

## Testing

- [x] `python -m unittest tests.test_create_masks_writes tests.test_create_masks -v` (21 passed)
- [x] actual rasterio write probe preserved pixels, CRS, and the caller profile
- [x] Black, isort, flake8, and detect-secrets
- [x] GIS, backend validation, and pre-landing code review found no blockers
- [ ] Full local discovery requires the training image: the workstation lacks PyTorch and two unchanged cleanup tests assume POSIX path separators. The roughly 40 GB image was intentionally not pulled locally; the PR workflow performs the remote image build.

## Related Work Items

None found.

## Review Notes

Design and rollout details: `spec/features/training-workflow-sync/design.md` and `spec/features/training-workflow-sync/rollout.md`.

This PR intentionally does not change label clustering, memory usage, task-log exposure, class-name matching, dependencies, infrastructure, or Function Apps.