### PR TITLE
chore(deps): bump geopandas 1.0.1 → 1.1.2 in /api/hastefuncapi

### DIFF
--- a/api/hastefuncapi/requirements.txt
+++ b/api/hastefuncapi/requirements.txt
@@ -28,7 +28,7 @@ pyyaml==6.0.3
 # to validate a publish request). Keep pystac < 1.12: 1.12+ defaults to
 # emitting STAC 1.1.0, but MPC Pro requires STAC 1.0.0 (stac.py STAC_VERSION).
 pystac[validation]==1.11.0
-geopandas==1.0.1
+geopandas==1.1.2
 pyproj==3.6.1
 pyogrio==0.10.0
 boto3==1.43.73


### PR DESCRIPTION
Aligns the **API** Function App with the **queues** app, which was bumped to `geopandas==1.1.2` in #176. Dependabot files one PR per manifest and only opened one for `/api/hastefuncqueues`, leaving `/api/hastefuncapi` at `1.0.1` — so the two apps would otherwise ship different geopandas versions.

## Compatibility
The publishing/PC code that uses geopandas (STAC building, tile/thumbnail, and the new Explorer rasterization) is green on geopandas 1.1.x — the full publishing suite passes on 1.1.4 locally, and the APIs used (`read_file`, `from_features`, `to_crs`, `estimate_utm_crs`, `total_bounds`) are stable across the 1.x line. The 1.0 breaking changes were already crossed at the `1.0.1` pin.

One-line change; `hastelib/pyproject.toml` already constrains `geopandas>=1.0`, so no conflict.