### PR TITLE
fix releases swallowed by concurrency issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,12 @@ on:
 permissions:
   contents: read
 
-# The Latest badge is a read-then-write against the remote tag list, so two
-# overlapping stable runs could otherwise leave it on the older release.
-# cancel-in-progress must stay false: a historical backfill dispatches one run
-# per tag, and cancelling them would silently skip releases.
+# Scoped per tag, never shared. GitHub keeps only one *pending* run per
+# concurrency group, so a single shared group makes each new dispatch cancel
+# the one queued behind it -- a backfill would silently lose releases.
+# Cross-run ordering is handled by reconciling the badge instead (below).
 concurrency:
-  group: product-release
+  group: product-release-${{ github.event.inputs.tag || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -95,21 +95,10 @@ jobs:
           TITLE: ${{ steps.notes.outputs.title }}
           PRERELEASE: ${{ steps.tag.outputs.prerelease }}
         run: |
-          FLAGS=()
+          # Never claim the badge here; the reconcile step below decides.
+          FLAGS=(--latest=false)
           if [ "$PRERELEASE" = "true" ]; then
-            FLAGS+=(--prerelease --latest=false)
-          else
-            # Only the newest stable release carries the "Latest" badge.
-            # Re-publishing notes for an older tag must never steal it, and
-            # backfilling history must not demote a newer release.
-            NEWEST=$(git tag --list 'v*'               | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'               | sort -V               | tail -1)
-            if [ "$TAG" = "$NEWEST" ]; then
-              echo "$TAG is the newest stable tag; taking the Latest badge."
-              FLAGS+=(--latest=true)
-            else
-              echo "$TAG is older than $NEWEST; leaving the Latest badge."
-              FLAGS+=(--latest=false)
-            fi
+            FLAGS+=(--prerelease)
           fi
           if gh release view "$TAG" --repo "${{ github.repository }}" \
               >/dev/null 2>&1; then
@@ -126,3 +115,21 @@ jobs:
               --verify-tag \
               "${FLAGS[@]}"
           fi
+
+      # Decided from the live release list, not a checkout-time snapshot, and
+      # applied to whichever release is highest rather than to this one. That
+      # makes it idempotent and order-independent: overlapping runs converge on
+      # the same answer, and a mis-set badge self-heals on the next release.
+      - name: Reconcile the Latest badge
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          STABLE=$(gh release list --repo "$REPO" --limit 200 --json tagName,isPrerelease,isDraft --jq '.[] | select(.isPrerelease == false and .isDraft == false) | .tagName')
+          NEWEST=$(echo "$STABLE" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+          if [ -z "$NEWEST" ]; then
+            echo 'No stable product release yet; leaving the badge alone.'
+            exit 0
+          fi
+          echo "Highest stable release is $NEWEST; giving it the Latest badge."
+          gh release edit "$NEWEST" --repo "$REPO" --latest=true

--- a/hastelib/tests/build/test_release_workflows.py
+++ b/hastelib/tests/build/test_release_workflows.py
@@ -276,12 +276,22 @@ class LatestBadgePolicyTests(unittest.TestCase):
         self.assertIn("--latest=true", self.workflow)
         self.assertIn("--latest=false", self.workflow)
 
-    def test_newest_stable_tag_is_computed_before_claiming_latest(self):
+    def test_badge_is_reconciled_from_the_live_release_list(self):
+        # Deciding from a checkout-time tag snapshot let a slow run write a
+        # stale badge; the live list makes concurrent runs converge instead.
+        self.assertIn("Reconcile the Latest badge", self.workflow)
+        self.assertIn("gh release list", self.workflow)
         self.assertIn("sort -V", self.workflow)
-        self.assertIn('[ "$TAG" = "$NEWEST" ]', self.workflow)
+        self.assertIn('gh release edit "$NEWEST"', self.workflow)
 
-    def test_prereleases_never_claim_latest(self):
-        self.assertIn("--prerelease --latest=false", self.workflow)
+    def test_publish_step_never_claims_the_badge_itself(self):
+        self.assertIn("FLAGS=(--latest=false)", self.workflow)
+
+    def test_prereleases_and_drafts_are_excluded_from_the_badge(self):
+        self.assertIn("--prerelease", self.workflow)
+        self.assertIn(
+            ".isPrerelease == false and .isDraft == false", self.workflow
+        )
 
     def test_full_history_is_fetched_so_tags_are_visible(self):
         self.assertIn("fetch-depth: 0", self.workflow)
@@ -295,8 +305,15 @@ class LatestBadgePolicyTests(unittest.TestCase):
         )
         self.assertNotIn("ref: ${{ steps.tag.outputs.tag }}", self.workflow)
 
-    def test_runs_are_serialized_without_cancelling_a_backfill(self):
-        self.assertIn("group: product-release", self.workflow)
+    def test_concurrency_group_is_scoped_per_tag(self):
+        # A single shared group is a trap: GitHub keeps only one *pending* run
+        # per group, so each new dispatch cancels the one queued behind it and
+        # a backfill silently loses releases.
+        self.assertIn(
+            "group: product-release-${{ github.event.inputs.tag "
+            "|| github.ref_name }}",
+            self.workflow,
+        )
         self.assertIn("cancel-in-progress: false", self.workflow)
 
 


### PR DESCRIPTION
## Description

The historical release backfill run after [#195](https://github.com/microsoft/haste/pull/195) merged **silently lost 4 of its 8 releases**. `release.yml` put every run in one shared concurrency group, and GitHub keeps only a **single pending run per group** — each new dispatch cancelled the one queued behind it. `v1.4.3`, `v1.4.5`, `v1.4.6` and `v1.4.7` were cancelled before they ever ran, with no failure signal; the workflow list just showed `cancelled`.

`cancel-in-progress: false` does not prevent this. It only protects the run that is already executing, not the one waiting behind it. The four missing releases were recovered by re-dispatching serially, but `main` still contains the version that ate them, and a future backfill — or any two tags pushed close together — would hit it again.

This PR fixes both the cancellation and the underlying badge race that motivated the shared group in the first place.

**Concurrency is now scoped per tag** (`product-release-${{ inputs.tag || github.ref_name }}`), so runs for different tags can never cancel each other.

**The Latest badge is reconciled from the live release list** instead of being decided from a checkout-time `git tag` snapshot. Each run now sets the badge on whichever release is *highest*, rather than on itself. That makes the operation idempotent and order-independent: concurrent runs converge on the same answer regardless of who writes last, and a badge left wrong by any means self-heals on the next release. This also closes the stale-snapshot race raised in review on #195, which the shared concurrency group had only papered over.

Fixes # <!-- issue number, if applicable -->

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [x] Infrastructure / CI change

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My changes follow the project's coding standards (PEP 8 for Python, ESLint rules for JS/TS)
- [x] I have added or updated tests that cover my changes
- [ ] Python tests pass locally (`cd hastelib && hatch run test:pytest`) and the UI lints clean (`cd ui && npm run lint`)
- [x] I have updated the relevant documentation (README, docs/, inline comments)
- [ ] I have added an entry to [CHANGELOG.md](../CHANGELOG.md) if this is a user-facing change

> Test note: `hatch run test:pytest` could not build its environment locally (`WinError 2`). The build tests were run with `python -m unittest discover -s hastelib/tests/build`, the command `hastegeo-build.yml` itself invokes. No UI code changed, so `npm run lint` was not run. No changelog entry: this fixes release tooling that has never shipped in a release, and is not user-facing.

## Testing

`LatestBadgePolicyTests` rewritten against the new design:

- `test_concurrency_group_is_scoped_per_tag` — pins the per-tag group, with a comment recording *why* a shared group is a trap, so it isn't "simplified" back
- `test_badge_is_reconciled_from_the_live_release_list` — asserts the reconcile step reads live releases and edits `$NEWEST`
- `test_publish_step_never_claims_the_badge_itself` — publish always passes `--latest=false`; only the reconcile step decides
- `test_prereleases_and_drafts_are_excluded_from_the_badge`

Every `run:` block was additionally syntax-checked with `bash -n` after substituting `${{ }}` expressions. That caught two latent defects in the previous version of this file: heredoc line-continuations collapsed into runs of spaces (valid bash, but accidental), and an escape that produced a literal newline inside a `printf`.

Verified live during the recovery: all 8 product releases now exist, `v2.0.0` correctly holds **Latest**, and `haste-binaries` retained all 149 assets with pinned wheel URLs still returning HTTP 200.

## Additional context

Two environment notes worth recording for whoever runs the next backfill:

- **`git push` of a tag hangs** in a non-interactive shell — a credential prompt with nowhere to render. Use `gh api` to create the tag object and then the ref.
- **Creating a tag ref via the API does not fire the `push` trigger**, so `release.yml` still has to be dispatched explicitly afterwards.

Not addressed here: build automation on tag push, and the `deploy-apps.yml` blank-image-tag default. Both remain tracked separately.

