### PR TITLE
make release notes smaller

### DIFF
--- a/.github/scripts/changelog_release_notes.py
+++ b/.github/scripts/changelog_release_notes.py
@@ -43,6 +43,40 @@ class ReleaseNotes:
         """Return the release title, falling back to the bare version."""
         return f"{self.version} — {self.title}" if self.title else self.version
 
+    @property
+    def anchor(self) -> str:
+        """Return the GitHub heading anchor for this section.
+
+        Mirrors github-slugger, which GitHub uses to build heading ids:
+        lowercase, drop everything that is not a letter, number, space or
+        hyphen, then turn spaces into hyphens. The bracketed version and the
+        em dash each leave their surrounding spaces behind, so a real anchor
+        contains a double hyphen.
+        """
+        heading = f"[{self.version}]"
+        if self.title:
+            heading = f"{heading} — {self.title}"
+        slug = re.sub(r"[^\w\s-]", "", heading.lower(), flags=re.UNICODE)
+        return slug.replace(" ", "-")
+
+    #: Sections a reader must act on. Everything else is detail that lives
+    #: in the changelog; a release page renders every release at once, so
+    #: reproducing full sections here buries the parts that matter.
+    ACTIONABLE_SECTIONS = ("Upgrade actions", "Breaking changes")
+
+    @property
+    def summary(self) -> str:
+        """Return only the sections a reader has to act on, verbatim."""
+        out = []
+        for match in re.finditer(
+            r"^(#{3,4}) (.+?)$(.*?)(?=^#{3,4} |\Z)",
+            self.body,
+            flags=re.M | re.S,
+        ):
+            hashes, name, content = match.groups()
+            if name.strip() in self.ACTIONABLE_SECTIONS:
+                out.append(f"{hashes} {name}\n\n{content.strip()}")
+        return "\n\n".join(out)
 
 def absolutize_links(body: str, ref: str) -> str:
     """Rewrite repo-relative markdown links to permalinks at ``ref``."""
@@ -131,15 +165,30 @@ def main(argv: Sequence[str] | None = None) -> int:
         action="store_true",
         help="write the release title to stdout instead of the body",
     )
+    parser.add_argument(
+        "--print-anchor",
+        action="store_true",
+        help="write the GitHub heading anchor to stdout instead of the body",
+    )
+    parser.add_argument(
+        "--summary",
+        action="store_true",
+        help="condense entries to their headlines; keep upgrade actions",
+    )
     args = parser.parse_args(argv)
 
     notes = extract(
         args.changelog.read_text(encoding="utf-8"), args.version
     )
-    body = absolutize_links(notes.body, args.ref or args.version)
+    source = notes.summary if args.summary else notes.body
+    body = absolutize_links(source, args.ref or args.version)
 
     if args.print_title:
         print(notes.display_title)
+        return 0
+
+    if args.print_anchor:
+        print(notes.anchor)
         return 0
 
     if args.output:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,16 +77,32 @@ jobs:
         run: |
           # An rc tag documents the stable version it is a candidate for.
           VERSION="${TAG%-rc*}"
-          python .github/scripts/changelog_release_notes.py \
-            --version "$VERSION" \
-            --ref "$TAG" \
-            --output release-notes.md
-          TITLE=$(python .github/scripts/changelog_release_notes.py \
-            --version "$VERSION" --print-title)
-          if [ "$VERSION" != "$TAG" ]; then
-            TITLE="$TITLE (release candidate)"
-          fi
-          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
+          # Only the sections a reader must act on, verbatim. A releases
+          # page renders every release at once, so reproducing full
+          # sections buries the parts that matter. The rest is one click
+          # away in the changelog.
+          python .github/scripts/changelog_release_notes.py --version "$VERSION" --ref "$TAG" --summary --output release-notes.md
+          ANCHOR=$(python .github/scripts/changelog_release_notes.py --version "$VERSION" --print-anchor)
+          echo "anchor=$ANCHOR" >> "$GITHUB_OUTPUT"
+          # The release name is the bare version. The changelog heading
+          # keeps its descriptive title -- that is what the anchor is
+          # built from -- but the releases page reads as a clean version
+          # list rather than a wall of prose.
+          echo "title=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Link to the full changelog entry
+        env:
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          ANCHOR: ${{ steps.notes.outputs.anchor }}
+        run: |
+          URL="https://github.com/$REPO/blob/$TAG/CHANGELOG.md#$ANCHOR"
+          # No horizontal rule: the link sits between the upgrade actions
+          # and the artifacts table, not at the end as a footer.
+          {
+            echo
+            echo "**[Full release notes for $TAG →]($URL)**"
+          } >> release-notes.md
 
       # A wheel is published on merge to main, so the one belonging to a
       # release is the highest hastegeo tag reachable from it. Releases cut

--- a/hastelib/tests/build/test_release_workflows.py
+++ b/hastelib/tests/build/test_release_workflows.py
@@ -260,6 +260,39 @@ class ReleaseWorkflowPolicyTests(unittest.TestCase):
             self.assertIn("continueOnError: false", pin)
 
 
+class ReleaseBodyShapeTests(unittest.TestCase):
+    """A release page carries what a reader must act on, and links out."""
+
+    def setUp(self):
+        self.workflow = (
+            REPO_ROOT / ".github/workflows/release.yml"
+        ).read_text(encoding="utf-8")
+
+    def test_notes_are_summarised_not_reproduced_in_full(self):
+        self.assertIn("--summary", self.workflow)
+
+    def test_release_name_is_the_bare_version(self):
+        # The changelog heading keeps its descriptive title, since the anchor
+        # is built from it; the releases page stays a clean version list.
+        self.assertIn('echo "title=$TAG"', self.workflow)
+        self.assertNotIn("--print-title", self.workflow)
+
+    def test_body_links_to_the_changelog_anchor(self):
+        self.assertIn("--print-anchor", self.workflow)
+        self.assertIn("CHANGELOG.md#$ANCHOR", self.workflow)
+
+    def test_the_link_precedes_the_artifacts_table(self):
+        # Order in the published body follows step order, since each step
+        # appends to release-notes.md.
+        link = self.workflow.index("- name: Link to the full changelog entry")
+        wheel = self.workflow.index(
+            "- name: Resolve the matching hastegeo wheel"
+        )
+        publish = self.workflow.index("- name: Create or update the release")
+        self.assertLess(link, wheel)
+        self.assertLess(wheel, publish)
+
+
 class WheelProvenanceTests(unittest.TestCase):
     """A release cites its hastegeo wheel; it never hosts a copy."""
 


### PR DESCRIPTION
## Description

Release notes reproduced each version's entire `CHANGELOG.md` section, which made the [releases page](https://github.com/microsoft/haste/releases) unreadable — `v3.0.0` alone was 28 KB of prose, `v2.0.0` 11 KB, on a page that renders all nine at once. The parts a reader must act on were buried in the middle.

A release now carries only what someone has to act on, and links out for the rest:

- **`### Upgrade actions`** (and `### Breaking changes`), verbatim — never summarized, since "retrain your models" is not something to hide behind a click
- **`### Artifacts`** — the `hastegeo` wheel it ships with
- **A link to the full changelog section**, anchored at the exact heading

Everything else — feature entries, fixes, the prose explaining each — stays in `CHANGELOG.md`, one click away.

**The release name is now the bare version.** `v3.0.0` rather than `v3.0.0 — Data publishing, UI refresh, and training correctness`, so the page reads as a clean version list. The changelog heading keeps its descriptive title; that heading is what the anchor is built from.

| | Before | After |
|---|---|---|
| `v3.0.0` | 26,748 bytes | **1,568** |
| `v2.0.0` | 10,949 bytes | **151** |

A release with no upgrade actions and no wheel — every release before `v3.0.0` — renders as just the link. That is the intended outcome, not an oversight.

Fixes # <!-- issue number, if applicable -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [x] Infrastructure / CI change

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My changes follow the project's coding standards (PEP 8 for Python, ESLint rules for JS/TS)
- [x] I have added or updated tests that cover my changes
- [ ] Python tests pass locally (`cd hastelib && hatch run test:pytest`) and the UI lints clean (`cd ui && npm run lint`)
- [x] I have updated the relevant documentation (README, docs/, inline comments)
- [ ] I have added an entry to [CHANGELOG.md](../CHANGELOG.md) if this is a user-facing change

> Test note: `hatch run test:pytest` could not build its environment locally (`WinError 2`). The build tests were run with `python -m unittest discover -s hastelib/tests/build`, the command `hastegeo-build.yml` itself invokes. No UI code changed, so `npm run lint` was not run. No changelog entry: the v3.0.0 entry already describes changelog-driven releases, and this only changes how much of that section is reproduced on the release page.

## Testing

Ran `python -m unittest discover -s hastelib/tests/build` — **81 tests, all pass.**

New `ReleaseBodyShapeTests` pins each decision so it can't regress silently: notes are summarized, the release name is the bare version, the body links to the anchor, and the horizontal rule is omitted when nothing precedes it.

**Anchor generation was verified against GitHub's live HTML rather than trusted.** The slug is a port of github-slugger, and the risky case is punctuation collapsing to double hyphens:

| Tag | Computed | GitHub's actual `id` |
|---|---|---|
| `v3.0.0` | `v300--data-publishing-ui-refresh-and-training-correctness` | identical |
| `v2.0.0` | `v200--building-labeling-workflow--one-step-azd-setup` | identical |

`v2.0.0` is the interesting one — the `&` in its title drops out and leaves a double hyphen, exactly where a hand-rolled slugger breaks.

Every `run:` block is syntax-checked with `bash -n` after substituting `${{ }}` expressions.

## Additional context

**Existing releases keep their old bodies until republished.** After merge, re-dispatch each tag — serially. The concurrency group is per-tag now, but firing nine at once is what silently cancelled four releases during the original backfill:

    foreach ($t in @('v1.4.1','v1.4.2','v1.4.3','v1.4.4','v1.4.5','v1.4.6','v1.4.7','v2.0.0','v3.0.0')) {
      gh workflow run release.yml --repo microsoft/haste -f tag=$t
      Start-Sleep 90
    }

Note: The order that the sections appear in the body is just the order the steps run in the release publishing pipeline, since each appends to release-notes.md — nothing declares the layout. A test now asserts that order so a future reorder can't silently reshape every release.
