### PR TITLE
fix(progress): shared workflow logs and truthful job status

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -33,14 +33,14 @@ jobs:
             RANGE="${BASE_SHA}..${HEAD_SHA}"
             echo "Scanning commit range: $RANGE"
             docker run --rm -v "$GITHUB_WORKSPACE:/repo" -w /repo ghcr.io/gitleaks/gitleaks:latest \
-              git --redact --exit-code 1 --log-opts="$RANGE"
+              git --verbose --redact=100 --exit-code 1 --log-opts="$RANGE"
           elif [[ "$EVENT_NAME" == "push" && -n "${BEFORE_SHA:-}" ]]; then
             RANGE="${BEFORE_SHA}..${HEAD_SHA}"
             echo "Scanning commit range: $RANGE"
             docker run --rm -v "$GITHUB_WORKSPACE:/repo" -w /repo ghcr.io/gitleaks/gitleaks:latest \
-              git --redact --exit-code 1 --log-opts="$RANGE"
+              git --verbose --redact=100 --exit-code 1 --log-opts="$RANGE"
           else
             echo "No commit range available; scanning repository snapshot"
             docker run --rm -v "$GITHUB_WORKSPACE:/repo" -w /repo ghcr.io/gitleaks/gitleaks:latest \
-              detect --no-git --redact --exit-code 1
+              detect --no-git --verbose --redact=100 --exit-code 1
           fi

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -7,3 +7,5 @@
 5ca8ae6adb13dc7e8ef6bd3dfe5b4f8528847a22:docker/README.md:generic-api-key:259
 5ca8ae6adb13dc7e8ef6bd3dfe5b4f8528847a22:docker/README.md:generic-api-key:367
 5ca8ae6adb13dc7e8ef6bd3dfe5b4f8528847a22:hastelib/pyproject.toml:generic-api-key:94
+# Mock Cosmos item/partition assertion, not an authentication credential.
+dab7ad874e0e9b92817b13f4fe9baf1fc1a05dc2:hastelib/tests/core/data_layer/test_conditional_metadata.py:generic-api-key:163

--- a/docker/training/code/run_workflow.py
+++ b/docker/training/code/run_workflow.py
@@ -15,20 +15,17 @@ import yaml
 
 
 def run_subprocess(command, step_name):
-    result = subprocess.run(command, capture_output=True, text=True)
+    log_progress(f"Starting {step_name}")
+    # Inherit the backend's streams instead of buffering an entire training run.
+    result = subprocess.run(command, text=True)
     if result.returncode != 0:
         log_progress(f"Error running {step_name}")
         print(f"Error running {step_name} (exit code: {result.returncode})")
-        if result.stdout:
-            print(f"[{step_name}] stdout:\n{result.stdout}")
-        if result.stderr:
-            print(f"[{step_name}] stderr:\n{result.stderr}")
         raise subprocess.CalledProcessError(
             result.returncode,
             result.args,
-            output=result.stdout,
-            stderr=result.stderr,
         )
+    log_progress(f"Completed {step_name}")
     return result
 
 

--- a/docker/training/code/tests/test_workflow_streaming.py
+++ b/docker/training/code/tests/test_workflow_streaming.py
@@ -1,0 +1,91 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import importlib.util
+import os
+import queue
+import subprocess
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPT = Path(__file__).resolve().parents[1] / "run_workflow.py"
+spec = importlib.util.spec_from_file_location(
+    "workflow_streaming_subject", SCRIPT
+)
+workflow = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(workflow)
+
+
+class TestWorkflowStreaming(unittest.TestCase):
+    def test_streams_stdout_and_stderr_before_child_completion(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            child = (
+                "import sys; "
+                "print('stdout-ready', flush=True); "
+                "print('stderr-ready', file=sys.stderr, flush=True); "
+                "sys.stdin.readline()"
+            )
+            wrapper = (
+                "import importlib.util,sys; "
+                f"s=importlib.util.spec_from_file_location('w', {str(SCRIPT)!r}); "
+                "w=importlib.util.module_from_spec(s); s.loader.exec_module(w); "
+                f"w.run_subprocess([sys.executable,'-c',{child!r}], 'test-step')"
+            )
+            env = dict(os.environ, AZ_BATCH_TASK_WORKING_DIR=tmp)
+            process = subprocess.Popen(
+                [sys.executable, "-c", wrapper],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=env,
+            )
+            observed = queue.Queue()
+            readers = [
+                threading.Thread(
+                    target=lambda stream=stream, name=name: observed.put(
+                        (name, stream.readline().strip())
+                    )
+                )
+                for name, stream in (
+                    ("stdout", process.stdout),
+                    ("stderr", process.stderr),
+                )
+            ]
+            for reader in readers:
+                reader.start()
+            try:
+                messages = dict(observed.get(timeout=10) for _ in readers)
+                self.assertEqual(messages["stdout"], "stdout-ready")
+                self.assertEqual(messages["stderr"], "stderr-ready")
+                self.assertIsNone(process.poll())
+            finally:
+                process.stdin.write("finish\n")
+                process.stdin.flush()
+                process.communicate(timeout=10)
+                for reader in readers:
+                    reader.join(timeout=1)
+            self.assertEqual(process.returncode, 0)
+            progress = (
+                Path(tmp) / "logs" / "workflow_progress.log"
+            ).read_text()
+            self.assertIn("Starting test-step", progress)
+            self.assertIn("Completed test-step", progress)
+
+    def test_nonzero_exit_remains_a_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, patch.dict(
+            os.environ, {"AZ_BATCH_TASK_WORKING_DIR": tmp}
+        ):
+            with self.assertRaises(subprocess.CalledProcessError) as error:
+                workflow.run_subprocess(
+                    [sys.executable, "-c", "raise SystemExit(17)"],
+                    "failing-step",
+                )
+            self.assertEqual(error.exception.returncode, 17)
+            log = (Path(tmp) / "logs" / "workflow_progress.log").read_text()
+            self.assertIn("Error running failing-step", log)
+            self.assertNotIn("Completed failing-step", log)

--- a/hastelib/src/hastegeo/core/processors/train.py
+++ b/hastelib/src/hastegeo/core/processors/train.py
@@ -1,6 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 import os
+import tempfile
+from datetime import datetime
+from typing import Iterable, Optional, Union
 
 from hastegeo.core.runners.submission import (
     TaskSubmissionPendingError,
@@ -132,6 +135,7 @@ class TrainPostprocessor(BaseTrainProcessor):
         self.config = config or Config()
 
     def process(self):
+        self._telemetry_unavailable = False
         self.logger.info(
             f"{self.__class__.__name__}.process: Processing model {self.model_data.modelId} with status {self.model_data.status}"
         )
@@ -170,24 +174,36 @@ class TrainPostprocessor(BaseTrainProcessor):
                 )
 
                 train_start_time, logs = self._get_training_logs()
+                self._append_workflow_progress()
+                have_metrics = False
                 if logs:
                     self.model_data.trainingJob.logs = logs
-                    self._calculate_upsert_training_metrics(job_completed=True)
+                    have_metrics = self._calculate_upsert_training_metrics(
+                        job_completed=True
+                    )
                     self.model_data.trainingJob.trainStartTime = (
                         train_start_time
                     )
-                    step = (
-                        int(self.model_data.trainingJob.completedEpochs or "0")
-                        + 1
-                    )
-                    message = (
-                        f"Training job completed successfully\n"
-                        f"trainStartTime: {self.model_data.trainingJob.trainStartTime or 'n/a'}\n"
-                        f"epoch: {self.model_data.trainingJob.completedEpochs}\n"
-                        f"elapsedDurationInMinutes: {self.model_data.trainingJob.totalElapsedTime}\n"
-                        f"completedDate: {self.model_data.trainingJob.completedDate}"
-                    )
-                    self._update_training_progress(message, step=step)
+                if not have_metrics:
+                    self.model_data.trainingJob.completedEpochs = None
+                    self.model_data.trainingJob.totalElapsedTime = None
+                    self.model_data.trainingJob.timePerEpoch = None
+                self.model_data.trainingJob.approxMinutesToComplete = "0"
+                message = (
+                    "Training job completed successfully\n"
+                    f"trainStartTime: {self.model_data.trainingJob.trainStartTime or 'n/a'}\n"
+                    f"epoch: {self.model_data.trainingJob.completedEpochs or 'n/a'}\n"
+                    f"elapsedDurationInMinutes: {self.model_data.trainingJob.totalElapsedTime or 'n/a'}\n"
+                    f"completedDate: {self.model_data.trainingJob.completedDate}"
+                )
+                if not have_metrics:
+                    message += "\nTraining metrics unavailable."
+                self.model_data.totalSteps = max(
+                    1, self.model_data.totalSteps or 0
+                )
+                self._update_training_progress(
+                    message, step=self.model_data.totalSteps
+                )
                 # Cleanup the task on the runner
                 self.runner.cleanup_task(
                     job_id=self.model_data.trainingJob.jobId,
@@ -224,10 +240,13 @@ class TrainPostprocessor(BaseTrainProcessor):
             else:
                 self.model_data.status = task_status
                 self.model_data.trainingJob.status = task_status
+                have_workflow_progress = self._append_workflow_progress()
                 train_start_time, logs = self._get_training_logs()
+                have_metrics = False
                 if logs:
                     self.model_data.trainingJob.logs = logs
-                    self._calculate_upsert_training_metrics()
+                    have_metrics = self._calculate_upsert_training_metrics()
+                if have_metrics:
                     self.model_data.trainingJob.trainStartTime = (
                         train_start_time
                     )
@@ -255,6 +274,16 @@ class TrainPostprocessor(BaseTrainProcessor):
                     self._update_training_progress(
                         message, step=self.model_data.currentStep
                     )
+                elif not have_workflow_progress:
+                    message = (
+                        "Training in progress; telemetry is unavailable"
+                        if self._telemetry_unavailable
+                        else "Training in progress; metrics are not yet available"
+                    )
+                    if message not in (self.model_data.statusMessage or ""):
+                        self._update_training_progress(
+                            message, step=self.model_data.currentStep or 0
+                        )
 
         return self.model_data
 
@@ -444,33 +473,89 @@ class TrainPostprocessor(BaseTrainProcessor):
         }
         return experiment_input_files
 
-    def _get_training_logs(self):
-        # file_name = self.batch_cluster.get_file_by_match_from_task(job_id, task_id,'events.out.tfevents')
-        # if file_name is None:
-        #     return None,None
-        # output = self.batch_cluster.get_file_from_task(job_id, task_id,file_name)
-        content = self.runner.get_filecontent_from_task(
-            job_id=self.model_data.trainingJob.jobId,
-            task_id=self.model_data.trainingJob.taskId,
-            filename="events.out.tfevents",
-            as_chunk=True,
+    def _read_training_output(
+        self, filename: str, as_chunks: bool = False
+    ) -> Optional[Union[str, Iterable[bytes]]]:
+        try:
+            return self.runner.get_filecontent_from_task(
+                job_id=self.model_data.trainingJob.jobId,
+                task_id=self.model_data.trainingJob.taskId,
+                filename=filename,
+                as_chunk=as_chunks,
+            )
+        except Exception as error:
+            self._telemetry_unavailable = True
+            self.logger.warning(
+                "Training telemetry %s is unavailable for task %s (%s)",
+                filename,
+                self.model_data.trainingJob.taskId,
+                type(error).__name__,
+            )
+            return None
+
+    def _get_training_logs(self) -> tuple[Optional[str], Optional[str]]:
+        content = self._read_training_output(
+            "events.out.tfevents", as_chunks=True
         )
         if content is None:
             return None, None
-        # Read the output content and save it to a local file
-        output_path = f"{self.temp_dir}/log.tfevents"
-        os.makedirs(os.path.dirname(output_path), exist_ok=True)
-        with open(output_path, "wb") as f:
-            for chunk in content:
-                f.write(chunk)
-        # Parse the TensorBoard event file using tensorboard package
+        output_path = None
         try:
-            start_time, events_json = parse_tb_event_logs(output_path)
-        except Exception as e:
-            self.logger.error(f"Error parsing Tensorboard Log file: {e}")
-            events_json = None
-            start_time = None
-        return start_time, events_json
+            os.makedirs(self.temp_dir, exist_ok=True)
+            with tempfile.NamedTemporaryFile(
+                dir=self.temp_dir, suffix=".tfevents", delete=False
+            ) as stream:
+                output_path = stream.name
+                for chunk in content:
+                    stream.write(chunk)
+            return parse_tb_event_logs(output_path)
+        except Exception as error:
+            self._telemetry_unavailable = True
+            self.logger.warning(
+                "Could not read training events for task %s (%s)",
+                self.model_data.trainingJob.taskId,
+                type(error).__name__,
+            )
+            return None, None
+        finally:
+            if output_path is not None:
+                try:
+                    os.unlink(output_path)
+                except OSError as error:
+                    self.logger.warning(
+                        "Could not remove temporary training events (%s)",
+                        type(error).__name__,
+                    )
+
+    def _append_workflow_progress(self) -> bool:
+        content = self._read_training_output("workflow_progress.log")
+        if content is None:
+            return False
+        if not isinstance(content, str):
+            self.logger.warning("Workflow progress is not text")
+            return False
+        have_progress = False
+        for line in content.splitlines():
+            if not line:
+                continue
+            timestamp, separator, message = line.partition("|")
+            try:
+                if not separator or not message.strip():
+                    raise ValueError("missing progress message")
+                datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+            except ValueError:
+                self.logger.warning(
+                    "Ignoring malformed workflow progress line"
+                )
+                continue
+            have_progress = True
+            if message not in (self.model_data.statusMessage or ""):
+                self._update_training_progress(
+                    message,
+                    step=self.model_data.currentStep or 0,
+                    timestamp=timestamp,
+                )
+        return have_progress
 
     def _get_task_error_details(self, job_id: str, task_id: str) -> str:
         """Retrieve user-safe error details from a failed batch task.
@@ -523,41 +608,38 @@ class TrainPostprocessor(BaseTrainProcessor):
 
         return "\n".join(error_parts)
 
-    def _calculate_upsert_training_metrics(self, job_completed=False):
+    def _calculate_upsert_training_metrics(
+        self, job_completed: bool = False
+    ) -> bool:
         # Calculate metrics from the TensorBoard event file and set the attrbutes in the TrainingJob
         try:
             if self.model_data.trainingJob.logs:
                 metrics = calculate_metrics(
-                    self.model_data.trainingJob.logs, self.model_data.maxEpochs
+                    self.model_data.trainingJob.logs,
+                    self.model_data.maxEpochs,
+                    job_completed=job_completed,
                 )
                 if metrics is None:
+                    if self.model_data.trainingJob.logs.strip() != "[]":
+                        self._telemetry_unavailable = True
                     return False
 
-                if job_completed:
-                    self.model_data.trainingJob.completedEpochs = (
-                        self.model_data.maxEpochs
-                    )
-                    self.model_data.trainingJob.approxMinutesToComplete = "0"
-                else:
-                    self.model_data.trainingJob.completedEpochs = (
-                        str(metrics["completed_epochs"])
-                        if metrics["completed_epochs"]
-                        else "0"
-                    )
-                    self.model_data.trainingJob.approxMinutesToComplete = (
-                        str(metrics["approx_time_to_complete"])
-                        if metrics["approx_time_to_complete"]
-                        else "n/a"
-                    )
-                    self.model_data.trainingJob.timePerEpoch = (
-                        str(metrics["time_per_epoch"])
-                        if metrics["time_per_epoch"]
-                        else "n/a"
-                    )
-
+                self.model_data.trainingJob.completedEpochs = str(
+                    metrics["completed_epochs"]
+                )
+                self.model_data.trainingJob.approxMinutesToComplete = (
+                    str(metrics["approx_time_to_complete"])
+                    if metrics["approx_time_to_complete"] is not None
+                    else "n/a"
+                )
+                self.model_data.trainingJob.timePerEpoch = (
+                    str(metrics["time_per_epoch"])
+                    if metrics["time_per_epoch"] is not None
+                    else "n/a"
+                )
                 self.model_data.trainingJob.totalElapsedTime = (
                     str(metrics["total_elapsed_time"])
-                    if metrics["total_elapsed_time"]
+                    if metrics["total_elapsed_time"] is not None
                     else "n/a"
                 )
 
@@ -575,14 +657,16 @@ class TrainPostprocessor(BaseTrainProcessor):
         self, message: str, step: int = None, timestamp: str = None
     ):
         if step is not None:
-            self.model_data.currentStep = int(step)
+            self.model_data.currentStep = max(0, int(step))
         else:
-            self.model_data.currentStep += 1
-        self.model_data.progressPct = round(
-            int(self.model_data.currentStep)
-            / int(self.model_data.totalSteps)
-            * 100,
-            2,
+            self.model_data.currentStep = (
+                self.model_data.currentStep or 0
+            ) + 1
+        total = self.model_data.totalSteps or 0
+        self.model_data.progressPct = (
+            round(min(100, self.model_data.currentStep / total * 100), 2)
+            if total > 0
+            else None
         )
         self.model_data.statusMessage = MetadataUtils.append_status_message(
             self.model_data.statusMessage, message, timestamp=timestamp

--- a/hastelib/src/hastegeo/core/runners/local.py
+++ b/hastelib/src/hastegeo/core/runners/local.py
@@ -21,6 +21,7 @@ from ..utils.atomic_files import LockUnavailableError, atomic_write
 from ..utils.local_permissions import LOCAL_TASK_ROOT
 from ..utils.logs import Logger
 from ..utils.metadata import MetadataUtils
+from ..utils.output_files import AmbiguousTaskOutputError, resolve_task_output
 from .base import BaseRunner
 from .local_lifecycle import (
     LIMIT_LABEL,
@@ -97,18 +98,20 @@ class LocalRunner(BaseRunner):
     def get_filecontent_from_task(
         self, job_id, task_id, filename, as_chunk=False
     ):
-        """Get file content from a completed local task."""
-        # For local runner, we can read directly from the work directory
+        """Read a live or completed output from this task's workspace."""
+        execution_key(job_id, task_id)
         job_dir = self.work_dir / job_id / task_id
-        file_path = job_dir / filename
-
-        # Also check outputs/ subdirectory where prepare_imagery writes files
-        if not file_path.exists():
-            outputs_file_path = job_dir / "outputs" / filename
-            if outputs_file_path.exists():
-                file_path = outputs_file_path
-
-        if file_path.exists():
+        try:
+            file_path = resolve_task_output(job_dir, filename)
+        except AmbiguousTaskOutputError:
+            self.logger.warning(
+                "Output %s is ambiguous for job %s task %s; unavailable",
+                filename,
+                job_id,
+                task_id,
+            )
+            return None
+        if file_path is not None:
             if as_chunk:
                 # Return file content in chunks
                 def read_chunks():
@@ -121,7 +124,7 @@ class LocalRunner(BaseRunner):
 
                 return read_chunks()
             else:
-                with open(file_path, "r") as f:
+                with open(file_path, "r", encoding="utf-8") as f:
                     return f.read()
         else:
             self.logger.warning(

--- a/hastelib/src/hastegeo/core/utils/output_files.py
+++ b/hastelib/src/hastegeo/core/utils/output_files.py
@@ -1,0 +1,72 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Resolve logical output names without searching outside one task."""
+
+import os
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Optional
+
+
+class AmbiguousTaskOutputError(ValueError):
+    """More than one file matches a logical task output."""
+
+
+def resolve_task_output(
+    task_directory: Path, requested_path: str
+) -> Optional[Path]:
+    normalized = requested_path.replace("\\", "/")
+    relative = PurePosixPath(normalized)
+    if (
+        not normalized
+        or "\x00" in normalized
+        or relative.is_absolute()
+        or PureWindowsPath(requested_path).drive
+        or ".." in relative.parts
+        or relative == PurePosixPath(".")
+    ):
+        raise ValueError("Task output must be a safe relative path")
+    root = task_directory.resolve()
+    if not root.is_dir():
+        return None
+
+    def checked_file(path: Path) -> Optional[Path]:
+        resolved = path.resolve()
+        if not resolved.is_relative_to(root):
+            raise ValueError("Task output resolves outside its workspace")
+        return resolved if resolved.is_file() else None
+
+    exact = checked_file(root.joinpath(*relative.parts))
+    if exact is not None:
+        return exact
+
+    suffix_matches = set()
+    prefix_matches = set()
+    suffix = "/" + relative.as_posix()
+    for directory, subdirectories, filenames in os.walk(
+        root, followlinks=False
+    ):
+        subdirectories[:] = [
+            name
+            for name in subdirectories
+            if not (Path(directory) / name).is_symlink()
+        ]
+        for filename in filenames:
+            path = Path(directory) / filename
+            name = path.relative_to(root).as_posix()
+            is_suffix = name.endswith(suffix)
+            is_prefix = filename.startswith(relative.name)
+            if not is_suffix and not is_prefix:
+                continue
+            candidate = checked_file(path)
+            if candidate is not None:
+                if is_suffix:
+                    suffix_matches.add(candidate)
+                if is_prefix:
+                    prefix_matches.add(candidate)
+    matches = suffix_matches or prefix_matches
+    if len(matches) > 1:
+        raise AmbiguousTaskOutputError(
+            f"Multiple task outputs match {requested_path!r}"
+        )
+    return next(iter(matches), None)

--- a/hastelib/src/hastegeo/core/utils/tbparser.py
+++ b/hastelib/src/hastegeo/core/utils/tbparser.py
@@ -1,14 +1,39 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 import json
+import math
 from datetime import datetime, timezone
+from typing import Optional, Union
 
+from hastegeo.core.utils.logs import Logger
 from tensorboard.backend.event_processing.event_accumulator import (  # type: ignore
     EventAccumulator,
 )
 
+logger = Logger.get_logger(__name__)
 
-def parse_tb_event_logs(log_file_path):
+
+def _finite_number(value: object) -> Optional[float]:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    try:
+        number = float(value)
+    except OverflowError:
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _metric_value(event, tag: str) -> Optional[float]:
+    if event is None:
+        return None
+    value = _finite_number(event.value)
+    if value is None:
+        logger.warning("TensorBoard metric %s is non-finite; unavailable", tag)
+        return None
+    return round(value, 6)
+
+
+def parse_tb_event_logs(log_file_path: str) -> tuple[Optional[str], str]:
     """
     Parses TensorBoard event logs to extract epoch, accuracy, and loss information.
 
@@ -32,7 +57,20 @@ def parse_tb_event_logs(log_file_path):
     events_by_tag = {}
     all_events = []
     for tag in ea.Tags().get("scalars", []):
-        scalar_events = ea.Scalars(tag)
+        scalar_events = []
+        for event in ea.Scalars(tag):
+            wall_time = _finite_number(event.wall_time)
+            try:
+                if wall_time is None:
+                    raise ValueError("non-finite timestamp")
+                datetime.fromtimestamp(wall_time, timezone.utc)
+            except (ValueError, OverflowError, OSError):
+                logger.warning(
+                    "TensorBoard metric %s has an invalid timestamp; ignored",
+                    tag,
+                )
+                continue
+            scalar_events.append(event)
         events_by_tag[tag] = {event.step: event for event in scalar_events}
         all_events.extend(scalar_events)
     start_timestamp = (
@@ -43,7 +81,14 @@ def parse_tb_event_logs(log_file_path):
     epoch_events = events_by_tag.get("epoch", {})
     latest_epoch_events = {}
     for step, event in epoch_events.items():
-        epoch_value = event.value
+        epoch_value = _finite_number(event.value)
+        if (
+            epoch_value is None
+            or epoch_value < 0
+            or not epoch_value.is_integer()
+        ):
+            logger.warning("TensorBoard epoch value is invalid; ignored")
+            continue
         if (
             epoch_value not in latest_epoch_events
             or step > latest_epoch_events[epoch_value].step
@@ -91,9 +136,9 @@ def parse_tb_event_logs(log_file_path):
                 else None
             ),
             "multiclassAccuracy": (
-                round(acc_event.value, 6) if acc_event else None
+                _metric_value(acc_event, "train_MulticlassAccuracy")
             ),
-            "loss": round(loss_event.value, 6) if loss_event else None,
+            "loss": _metric_value(loss_event, "train_loss"),
             "wallTime": datetime.fromtimestamp(
                 epoch_event.wall_time, timezone.utc
             ).strftime("%Y-%m-%d %H:%M:%S"),
@@ -106,12 +151,17 @@ def parse_tb_event_logs(log_file_path):
             start_timestamp, timezone.utc
         ).strftime("%Y-%m-%d %H:%M:%S")
 
-    return start_timestamp, json.dumps(result, default=str)
+    return start_timestamp, json.dumps(result, allow_nan=False)
 
 
 def calculate_metrics(
-    logs, maxEpochs, time_field="elapsedDurationInMinutes", epoch_field="epoch"
-):
+    logs: Optional[str],
+    maxEpochs: Union[str, int, None],
+    time_field: str = "elapsedDurationInMinutes",
+    epoch_field: str = "epoch",
+    *,
+    job_completed: bool = False,
+) -> Optional[dict]:
     """
     Calculate completion metrics from TensorBoard logs.
 
@@ -128,41 +178,84 @@ def calculate_metrics(
             - 'total_elapsed_time' (float): The total elapsed time.
             - 'time_per_epoch' (float): The average time per epoch.
     """
-    if logs is not None:
-        try:
-            logs = json.loads(logs)
-        except (TypeError, json.JSONDecodeError):
-            return None
-        epoch_0_time = None
-        for log in logs:
-            if time_field in log and log[epoch_field] == 0:
-                epoch_0_time = log[time_field]
-                break
-        if epoch_0_time:
-            total_epochs = int(maxEpochs) if maxEpochs else 0
-            total_elapsed_time = sum(
-                log[time_field] for log in logs if time_field in log
-            )
-            total_elapsed_time = round(total_elapsed_time, 2)
-            completed_epochs_logs = list(
-                log for log in logs if log[epoch_field] < total_epochs
-            )
-            completed_epochs = max(0, len(completed_epochs_logs) - 1)
+    if logs is None:
+        return None
+    try:
+        records = json.loads(logs)
+        target = int(maxEpochs) if maxEpochs not in (None, "") else None
+    except (TypeError, ValueError):
+        logger.warning("Training progress has invalid JSON or epoch target")
+        return None
+    if not isinstance(records, list) or (target is not None and target < 1):
+        logger.warning("Training progress has invalid records or epoch target")
+        return None
+    if not records:
+        return None
 
-            if completed_epochs > 0:
-                avg_time_per_epoch = round(epoch_0_time, 2)
-                total_time = total_epochs * avg_time_per_epoch
-                time_to_completion = round(
-                    max(0, total_time - total_elapsed_time), 2
-                )
-                time_per_epoch = round(avg_time_per_epoch, 2)
-            else:
-                time_to_completion = None
-                time_per_epoch = None
-            return {
-                "completed_epochs": completed_epochs,
-                "approx_time_to_complete": time_to_completion,
-                "total_elapsed_time": total_elapsed_time,
-                "time_per_epoch": time_per_epoch,
-            }
-    return None
+    durations = {}
+    for record in records:
+        if not isinstance(record, dict):
+            logger.warning("Training progress record is not an object")
+            return None
+        epoch = _finite_number(record.get(epoch_field))
+        duration = _finite_number(record.get(time_field))
+        if (
+            epoch is None
+            or epoch < 0
+            or not epoch.is_integer()
+            or duration is None
+            or duration < 0
+        ):
+            logger.warning(
+                "Training progress has an invalid epoch or duration"
+            )
+            return None
+        durations[int(epoch)] = duration
+
+    current_epoch = max(durations)
+    completed_epochs = current_epoch + (1 if job_completed else 0)
+    if target is not None:
+        completed_epochs = min(completed_epochs, target)
+    completed_durations = [
+        duration
+        for epoch, duration in durations.items()
+        if (job_completed or epoch < current_epoch) and duration > 0
+    ]
+    time_per_epoch = (
+        sum(completed_durations) / len(completed_durations)
+        if completed_durations
+        else None
+    )
+    elapsed = sum(durations.values())
+    if not math.isfinite(elapsed) or (
+        time_per_epoch is not None and not math.isfinite(time_per_epoch)
+    ):
+        logger.warning("Training progress duration exceeds numeric limits")
+        return None
+    remaining = None
+    if job_completed:
+        remaining = 0.0
+    elif time_per_epoch is not None and target is not None:
+        current_duration = durations[current_epoch]
+        try:
+            remaining = max(
+                0.0,
+                (target - completed_epochs) * time_per_epoch
+                - current_duration,
+            )
+        except OverflowError:
+            logger.warning("Training ETA exceeds numeric limits; unavailable")
+            remaining = None
+        if remaining is not None and not math.isfinite(remaining):
+            logger.warning("Training ETA exceeds numeric limits; unavailable")
+            remaining = None
+    return {
+        "completed_epochs": completed_epochs,
+        "approx_time_to_complete": (
+            round(remaining, 2) if remaining is not None else None
+        ),
+        "total_elapsed_time": round(elapsed, 2),
+        "time_per_epoch": (
+            round(time_per_epoch, 2) if time_per_epoch is not None else None
+        ),
+    }

--- a/hastelib/tests/build/test_release_workflows.py
+++ b/hastelib/tests/build/test_release_workflows.py
@@ -9,6 +9,22 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 class ReleaseWorkflowPolicyTests(unittest.TestCase):
+    def test_secret_scan_diagnostics_keep_full_redaction(self):
+        text = (REPO_ROOT / ".github/workflows/secret-scan.yml").read_text(
+            encoding="utf-8"
+        )
+        commands = [
+            line.strip()
+            for line in text.splitlines()
+            if line.strip().startswith(("git --", "detect --"))
+        ]
+        self.assertEqual(len(commands), 3)
+        for command in commands:
+            with self.subTest(command=command):
+                self.assertIn("--verbose", command)
+                self.assertIn("--redact=100", command)
+                self.assertIn("--exit-code 1", command)
+
     def test_validation_runs_for_pull_requests_against_stack_branches(self):
         for name in (
             "hastegeo-build.yml",

--- a/hastelib/tests/core/data_layer/test_conditional_metadata.py
+++ b/hastelib/tests/core/data_layer/test_conditional_metadata.py
@@ -160,7 +160,7 @@ def test_cosmos_replaces_only_the_expected_partitioned_revision(
     current, version = cosmos.load_json_versioned("key", "model")
     cosmos.save_json_if_version("key", "model", current, version)
     cosmos.container.read_item.assert_called_once_with(
-        item="model_key", partition_key="partition"
+        item="model_key", partition_key="partition"  # gitleaks:allow
     )
     options = cosmos.container.replace_item.call_args.kwargs
     assert options["etag"] == "etag-1"

--- a/hastelib/tests/core/processors/test_training_progress.py
+++ b/hastelib/tests/core/processors/test_training_progress.py
@@ -1,0 +1,166 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import json
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+from hastegeo.core.config import Config
+from hastegeo.core.models.projects import Model, TrainingJob
+from hastegeo.core.processors.train import TrainPostprocessor
+
+
+class TestTrainingProgress(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.processor = TrainPostprocessor.__new__(TrainPostprocessor)
+        self.processor.config = Config()
+        self.statuses = self.processor.config.get_status_types()
+        self.processor.model_data = Model(
+            modelId="42",
+            projectId="project-1",
+            maxEpochs="1",
+            status=self.statuses.IN_PROGRESS.value,
+            currentStep=0,
+            totalSteps=2,
+            progressPct=0,
+            trainingJob=TrainingJob(
+                jobId="job-1",
+                taskId="task-1",
+                status=self.statuses.IN_PROGRESS.value,
+            ),
+        )
+        self.processor.temp_dir = self.temporary.name
+        self.processor.logger = MagicMock()
+        self.processor.queue_client = MagicMock()
+        self.processor.runner = MagicMock()
+        self.processor.runner.get_filecontent_from_task.return_value = None
+        self.processor.runner.get_task_status.return_value = (
+            self.statuses.IN_PROGRESS.value
+        )
+
+    def test_completion_is_reported_without_tensorboard(self) -> None:
+        self.processor.runner.get_task_status.return_value = (
+            self.statuses.COMPLETED.value
+        )
+
+        result = self.processor.process()
+
+        self.assertEqual(result.status, self.statuses.COMPLETED.value)
+        self.assertEqual(result.progressPct, 100)
+        self.assertEqual(result.currentStep, result.totalSteps)
+        self.assertIsNone(result.trainingJob.completedEpochs)
+        self.assertIn("completed successfully", result.statusMessage)
+        self.processor.runner.cleanup_task.assert_called_once()
+        self.processor.queue_client.put_message.assert_not_called()
+
+    def test_running_without_metrics_does_not_crash_or_claim_completion(
+        self,
+    ) -> None:
+        result = self.processor.process()
+
+        self.assertEqual(result.status, self.statuses.IN_PROGRESS.value)
+        self.assertEqual(result.currentStep, 0)
+        self.assertIn("metrics are not yet available", result.statusMessage)
+        self.processor.queue_client.put_message.assert_not_called()
+        self.processor.runner.cleanup_task.assert_not_called()
+
+    def test_empty_event_results_do_not_convert_unset_epoch_to_int(
+        self,
+    ) -> None:
+        with patch.object(
+            self.processor, "_get_training_logs", return_value=(None, "[]")
+        ):
+            result = self.processor.process()
+        self.assertEqual(result.status, self.statuses.IN_PROGRESS.value)
+        self.assertEqual(result.currentStep, 0)
+        self.processor.queue_client.put_message.assert_not_called()
+
+    def test_epoch_zero_and_zero_elapsed_are_retained(self) -> None:
+        logs = json.dumps([{"epoch": 0, "elapsedDurationInMinutes": 0.0}])
+        with patch.object(
+            self.processor, "_get_training_logs", return_value=("start", logs)
+        ):
+            result = self.processor.process()
+        self.assertEqual(result.trainingJob.completedEpochs, "0")
+        self.assertEqual(result.trainingJob.totalElapsedTime, "0.0")
+        self.assertEqual(result.trainingJob.approxMinutesToComplete, "n/a")
+        self.assertEqual(result.currentStep, 1)
+        self.assertEqual(result.progressPct, 50)
+        self.assertIn("calculating...", result.statusMessage)
+
+    def test_workflow_stage_is_visible_before_training_metrics(self) -> None:
+        def output(**kwargs):
+            if kwargs["filename"] == "workflow_progress.log":
+                return "2026-01-01T00:00:00+00:00|Starting fine_tune.py\n"
+            return None
+
+        self.processor.runner.get_filecontent_from_task.side_effect = output
+        result = self.processor.process()
+        self.assertIn("Starting fine_tune.py", result.statusMessage)
+        self.assertNotIn("metrics are not yet available", result.statusMessage)
+        self.assertEqual(result.status, self.statuses.IN_PROGRESS.value)
+
+    def test_telemetry_failure_does_not_change_execution_outcome(self) -> None:
+        self.processor.runner.get_filecontent_from_task.side_effect = (
+            RuntimeError("provider error with private diagnostics")
+        )
+        self.processor.runner.get_task_status.return_value = (
+            self.statuses.COMPLETED.value
+        )
+        result = self.processor.process()
+        self.assertEqual(result.status, self.statuses.COMPLETED.value)
+        self.assertEqual(result.progressPct, 100)
+        self.assertNotIn("private diagnostics", result.statusMessage)
+        self.assertTrue(self.processor.logger.warning.called)
+
+    def test_running_telemetry_error_is_not_reported_as_startup_delay(
+        self,
+    ) -> None:
+        self.processor.runner.get_filecontent_from_task.side_effect = (
+            RuntimeError("private provider detail")
+        )
+        result = self.processor.process()
+        self.assertEqual(result.status, self.statuses.IN_PROGRESS.value)
+        self.assertIn("telemetry is unavailable", result.statusMessage)
+        self.assertNotIn("private provider detail", result.statusMessage)
+
+    def test_completion_with_legacy_missing_steps_is_safe(self) -> None:
+        self.processor.model_data.totalSteps = None
+        self.processor.runner.get_task_status.return_value = (
+            self.statuses.COMPLETED.value
+        )
+        result = self.processor.process()
+        self.assertEqual(result.progressPct, 100)
+        self.assertEqual(result.totalSteps, 1)
+
+    def test_failed_execution_does_not_become_completed(self) -> None:
+        self.processor.runner.get_task_status.return_value = (
+            self.statuses.FAILED.value
+        )
+        result = self.processor.process()
+        self.assertEqual(result.status, self.statuses.FAILED.value)
+        self.assertNotIn("completed successfully", result.statusMessage)
+        self.assertNotEqual(result.progressPct, 100)
+
+    def test_completed_epochs_are_observed_not_fabricated_from_target(
+        self,
+    ) -> None:
+        self.processor.model_data.maxEpochs = "20"
+        self.processor.model_data.trainingJob.logs = json.dumps(
+            [{"epoch": 0, "elapsedDurationInMinutes": 2.0}]
+        )
+        self.assertTrue(
+            self.processor._calculate_upsert_training_metrics(
+                job_completed=True
+            )
+        )
+        self.assertEqual(
+            self.processor.model_data.trainingJob.completedEpochs, "1"
+        )
+        self.assertEqual(
+            self.processor.model_data.trainingJob.approxMinutesToComplete,
+            "0.0",
+        )

--- a/hastelib/tests/core/utils/test_output_files.py
+++ b/hastelib/tests/core/utils/test_output_files.py
@@ -1,0 +1,119 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from hastegeo.core.utils.output_files import (
+    AmbiguousTaskOutputError,
+    resolve_task_output,
+)
+
+
+class TestTaskOutputResolution(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name) / "task"
+        self.root.mkdir()
+
+    def write(self, relative: str, content: bytes = b"output") -> Path:
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+        return path.resolve()
+
+    def test_exact_path_wins_over_nested_matches(self) -> None:
+        exact = self.write("events.out.tfevents")
+        self.write("logs/events.out.tfevents")
+        self.assertEqual(
+            resolve_task_output(self.root, "events.out.tfevents"), exact
+        )
+
+    def test_nested_file_and_generated_basename_are_found(self) -> None:
+        event = self.write(
+            "logs/model_42/version_0/events.out.tfevents.123.host.0"
+        )
+        self.assertEqual(
+            resolve_task_output(self.root, "events.out.tfevents"), event
+        )
+
+    def test_nested_exact_suffix_precedes_basename_prefix(self) -> None:
+        exact = self.write("outputs/logs/progress.log")
+        self.write("elsewhere/progress.log.extra")
+        self.assertEqual(
+            resolve_task_output(self.root, "logs/progress.log"), exact
+        )
+
+    def test_multiple_prefix_matches_are_not_selected_arbitrarily(
+        self,
+    ) -> None:
+        self.write("logs/version_0/events.out.tfevents.123")
+        self.write("logs/version_1/events.out.tfevents.456")
+        with self.assertRaises(AmbiguousTaskOutputError):
+            resolve_task_output(self.root, "events.out.tfevents")
+
+    def test_multiple_nested_exact_matches_are_ambiguous(self) -> None:
+        self.write("one/progress.log")
+        self.write("two/progress.log")
+        with self.assertRaises(AmbiguousTaskOutputError):
+            resolve_task_output(self.root, "progress.log")
+
+    def test_missing_output_is_unavailable(self) -> None:
+        self.assertIsNone(resolve_task_output(self.root, "progress.log"))
+        self.assertIsNone(
+            resolve_task_output(self.root / "missing", "progress.log")
+        )
+
+    def test_unsafe_paths_are_rejected(self) -> None:
+        for path in (
+            "",
+            ".",
+            "..",
+            "../secret",
+            r"..\secret",
+            "/tmp/x",
+            r"C:\x",
+            "a\x00b",
+        ):
+            with self.subTest(path=path), self.assertRaises(ValueError):
+                resolve_task_output(self.root, path)
+
+    def test_symlink_cannot_escape_task(self) -> None:
+        outside = self.root.parent / "outside"
+        outside.write_text("private")
+        link = self.root / "progress.log"
+        try:
+            link.symlink_to(outside)
+        except OSError as error:
+            self.skipTest(f"Symlink creation unavailable: {error}")
+        with self.assertRaises(ValueError):
+            resolve_task_output(self.root, "progress.log")
+
+    def test_local_reader_returns_event_bytes_and_logs_ambiguity(self) -> None:
+        from hastegeo.core.runners.local import LocalRunner
+
+        runner = LocalRunner.__new__(LocalRunner)
+        runner.work_dir = self.root
+        runner.logger = MagicMock()
+        self.write(
+            "job/task/logs/model/version_0/events.out.tfevents.123",
+            b"\x00binary\xff",
+        )
+        self.assertEqual(
+            b"".join(
+                runner.get_filecontent_from_task(
+                    "job", "task", "events.out.tfevents", as_chunk=True
+                )
+            ),
+            b"\x00binary\xff",
+        )
+        self.write("job/task/logs/version_1/events.out.tfevents.456")
+        self.assertIsNone(
+            runner.get_filecontent_from_task(
+                "job", "task", "events.out.tfevents", as_chunk=True
+            )
+        )
+        runner.logger.warning.assert_called_once()

--- a/hastelib/tests/core/utils/test_tbparser.py
+++ b/hastelib/tests/core/utils/test_tbparser.py
@@ -1,0 +1,166 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import json
+import math
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from hastegeo.core.utils.tbparser import calculate_metrics, parse_tb_event_logs
+from tensorboard.compat.proto.event_pb2 import Event
+from tensorboard.compat.proto.summary_pb2 import Summary
+from tensorboard.summary.writer.event_file_writer import EventFileWriter
+
+
+class TestTensorBoardProgress(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.writer = EventFileWriter(self.temporary.name)
+        self.addCleanup(self.writer.close)
+        self.writer.flush()
+        self.path = next(
+            Path(self.temporary.name).glob("events.out.tfevents.*")
+        )
+
+    def write_event(
+        self, step: int, wall_time: float, **values: float
+    ) -> None:
+        self.writer.add_event(
+            Event(
+                step=step,
+                wall_time=wall_time,
+                summary=Summary(
+                    value=[
+                        Summary.Value(tag=tag, simple_value=value)
+                        for tag, value in values.items()
+                    ]
+                ),
+            )
+        )
+        self.writer.flush()
+
+    def test_empty_event_file_is_not_a_failure(self) -> None:
+        start, records = parse_tb_event_logs(str(self.path))
+        self.assertIsNone(start)
+        self.assertEqual(json.loads(records), [])
+        self.assertIsNone(calculate_metrics(records, "1"))
+
+    def test_growing_epoch_zero_reports_real_elapsed_time(self) -> None:
+        self.write_event(0, 100, epoch=0, train_loss=0.8)
+        _, initial = parse_tb_event_logs(str(self.path))
+        first = calculate_metrics(initial, "2")
+        self.assertEqual(first["completed_epochs"], 0)
+        self.assertEqual(first["total_elapsed_time"], 0)
+        self.assertIsNone(first["approx_time_to_complete"])
+
+        self.write_event(50, 160, epoch=0, train_loss=0.5)
+        _, updated = parse_tb_event_logs(str(self.path))
+        current = calculate_metrics(updated, "2")
+        self.assertEqual(current["completed_epochs"], 0)
+        self.assertEqual(current["total_elapsed_time"], 1)
+        self.assertIsNone(current["approx_time_to_complete"])
+        self.assertEqual(json.loads(updated)[0]["loss"], 0.5)
+
+    def test_nonfinite_metrics_are_unavailable_not_zero(self) -> None:
+        self.write_event(
+            0,
+            100,
+            epoch=0,
+            train_loss=math.nan,
+            train_MulticlassAccuracy=math.inf,
+        )
+        with patch("hastegeo.core.utils.tbparser.logger") as logger:
+            _, records = parse_tb_event_logs(str(self.path))
+        record = json.loads(records)[0]
+        self.assertIsNone(record["loss"])
+        self.assertIsNone(record["multiclassAccuracy"])
+        self.assertNotIn("NaN", records)
+        self.assertNotIn("Infinity", records)
+        self.assertEqual(logger.warning.call_count, 2)
+
+    def test_invalid_epoch_is_ignored_with_diagnostic(self) -> None:
+        self.write_event(0, 100, epoch=math.nan, train_loss=0.5)
+        with patch("hastegeo.core.utils.tbparser.logger") as logger:
+            _, records = parse_tb_event_logs(str(self.path))
+        self.assertEqual(json.loads(records), [])
+        logger.warning.assert_called_once()
+
+    def test_partial_trailing_event_does_not_erase_valid_events(self) -> None:
+        self.write_event(0, 100, epoch=0, train_loss=0.5)
+        self.writer.close()
+        with self.path.open("ab") as stream:
+            stream.write(b"\x01\x02\x03")
+        _, records = parse_tb_event_logs(str(self.path))
+        self.assertEqual(json.loads(records)[0]["loss"], 0.5)
+
+
+class TestCalculateMetrics(unittest.TestCase):
+    def records(self, *durations: float, start_epoch: int = 0) -> str:
+        return json.dumps(
+            [
+                {
+                    "epoch": start_epoch + index,
+                    "elapsedDurationInMinutes": value,
+                }
+                for index, value in enumerate(durations)
+            ]
+        )
+
+    def test_zero_duration_is_valid_progress(self) -> None:
+        metrics = calculate_metrics(self.records(0), "1")
+        self.assertEqual(metrics["completed_epochs"], 0)
+        self.assertEqual(metrics["total_elapsed_time"], 0)
+        self.assertIsNone(metrics["time_per_epoch"])
+
+    def test_eta_uses_completed_not_partial_epoch_duration(self) -> None:
+        metrics = calculate_metrics(self.records(10, 2), "3")
+        self.assertEqual(metrics["completed_epochs"], 1)
+        self.assertEqual(metrics["time_per_epoch"], 10)
+        self.assertEqual(metrics["total_elapsed_time"], 12)
+        self.assertEqual(metrics["approx_time_to_complete"], 18)
+
+    def test_completed_run_counts_the_final_epoch(self) -> None:
+        metrics = calculate_metrics(self.records(10), "1", job_completed=True)
+        self.assertEqual(metrics["completed_epochs"], 1)
+        self.assertEqual(metrics["approx_time_to_complete"], 0)
+        self.assertEqual(metrics["time_per_epoch"], 10)
+
+    def test_completed_run_does_not_claim_unobserved_target_epochs(
+        self,
+    ) -> None:
+        metrics = calculate_metrics(self.records(10), "20", job_completed=True)
+        self.assertEqual(metrics["completed_epochs"], 1)
+        self.assertEqual(metrics["approx_time_to_complete"], 0)
+
+    def test_resumed_epoch_counter_does_not_restart_at_zero(self) -> None:
+        metrics = calculate_metrics(self.records(10, 2, start_epoch=5), "10")
+        self.assertEqual(metrics["completed_epochs"], 6)
+        self.assertEqual(metrics["approx_time_to_complete"], 38)
+
+    def test_invalid_records_do_not_produce_fabricated_progress(self) -> None:
+        for logs in (
+            "not-json",
+            "{}",
+            "[null]",
+            self.records(math.nan),
+            self.records(-1),
+            '[{"epoch":0}]',
+        ):
+            with self.subTest(logs=logs):
+                self.assertIsNone(calculate_metrics(logs, "2"))
+
+    def test_missing_target_has_no_eta(self) -> None:
+        metrics = calculate_metrics(self.records(10, 2), None)
+        self.assertEqual(metrics["completed_epochs"], 1)
+        self.assertIsNone(metrics["approx_time_to_complete"])
+
+    def test_numeric_overflow_cannot_escape_as_invalid_json_numbers(
+        self,
+    ) -> None:
+        self.assertIsNone(calculate_metrics(self.records(1e308, 1e308), "3"))
+        metrics = calculate_metrics(self.records(10, 2), str(10**400))
+        self.assertIsNone(metrics["approx_time_to_complete"])
+        json.dumps(metrics, allow_nan=False)

--- a/spec/features/job-progress-observability/README.md
+++ b/spec/features/job-progress-observability/README.md
@@ -1,0 +1,17 @@
+# Shared job progress and workflow observability
+
+**Status:** implemented
+
+Make local and remote runs use the same existing TensorBoard and workflow-log
+reporting path. Correct output discovery, incomplete telemetry handling,
+terminal progress, live subprocess logs, and status presentation without
+changing model training semantics.
+
+This prerequisite follows local lifecycle/state fixes and remains independent
+of the backend-neutral/AML feature that will be integrated above it.
+
+## Documents
+
+- [Design](design.md)
+- [User stories and agent assignments](user-stories.md)
+- [Implementation plan and validation](plan.md)

--- a/spec/features/job-progress-observability/design.md
+++ b/spec/features/job-progress-observability/design.md
@@ -1,0 +1,53 @@
+# Design: shared job progress and workflow observability
+
+## Scope
+
+Reuse TensorBoard event files and `logs/workflow_progress.log` for every
+backend. No local-only progress format, new polling transport, training
+parameter change, or loss/data transformation is introduced.
+
+## Output discovery
+
+Local reads first resolve the exact requested path within the task directory.
+If absent, find a unique nested suffix match, then a unique basename-prefix
+match for generated names such as TensorBoard events. All discovery stays
+inside that execution's workspace, including symlink resolution.
+Ambiguous matches produce an explicit unavailable-telemetry diagnostic,
+never an arbitrary result or cross-job search.
+
+## Shared progress processing
+
+The existing TensorBoard parser remains authoritative for recorded epochs,
+accuracy, and training loss. Empty or partially written files are normal
+while a job starts. Missing telemetry must not change execution status or
+cause integer conversion of unset counters.
+
+Keep non-finite metric values unavailable in the API representation and log
+the condition; never substitute zero or modify the original event file.
+Only estimate remaining time after a completed epoch provides a usable
+duration. Recorded zero elapsed time is valid, not a missing-value sentinel.
+
+Business completion sets terminal progress independently of event-file
+availability. A failed or cancelled job does not become successful merely
+because its percentage or logs suggest completion.
+
+## Workflow logs
+
+Subprocess stdout and stderr flow directly to the backend's existing output
+streams while each step runs. The parent records stage boundaries and
+nonzero exits in the existing workflow log. It does not retain an unbounded
+copy of child output or suppress successful child output until exit.
+
+## UI
+
+Use the existing project/home polling. Display valid states even when the
+message list is empty. Render unknown progress as indeterminate rather than
+inventing a percentage; show terminal status regardless of missing counters.
+Keep FluentUI, current styling, and old-record compatibility.
+
+## Compatibility
+
+The prerequisite uses existing `BaseRunner` and job-model interfaces and has
+no dependency on AML types or SDKs. The later backend-neutral integration
+must preserve these read/progress semantics. Training budgets, labels,
+checkpoints, and raw TensorBoard metrics remain unchanged.

--- a/spec/features/job-progress-observability/plan.md
+++ b/spec/features/job-progress-observability/plan.md
@@ -1,0 +1,38 @@
+# Plan: shared job progress
+
+## Tasks
+
+| Task | Agent | Status |
+|---|---|---|
+| Safe job-scoped output discovery | backend-dev | done |
+| Partial/empty/non-finite TensorBoard handling | backend-dev | done |
+| Shared running/terminal progress updates | backend-dev | done |
+| Live subprocess streams and stage messages | backend-dev | done |
+| Empty-message and indeterminate UI states | ui | done |
+| Regression and integration validation | backend-validation; ui-validation | complete on the lifecycle prerequisite; final AML integration remains a separate gate |
+
+## Validation
+
+- Unit tests for exact/nested/prefix discovery, ambiguity, missing files,
+  and traversal/symlink boundaries.
+- Real TensorBoard fixtures for empty and growing event files, epoch zero,
+  missing/non-finite metrics, and completed versus running epoch counts.
+- Processor tests for successful completion without telemetry and running
+  polling before metrics are available.
+- Subprocess tests that observe stdout/stderr before child completion.
+- UI helper tests plus lint/build and deterministic browser checks.
+- Revalidate this prerequisite after rebasing onto the lifecycle prerequisite,
+  then verify the final backend-neutral integration separately.
+
+## Current evidence and baseline limitations
+
+Focused backend tests and the UI status helper cases pass. Browser checks
+exercise queued, unknown-progress, determinate, terminal, empty-message,
+legacy-record, and reduced-motion behavior. The production UI build passes
+with the exact locked dependencies.
+
+The full library run has one unchanged baseline failure:
+`test_artifacts.py::test_zip` calls the nonexistent `ArtifactProcessor.zip`
+method. Full UI lint also reports findings in unchanged files; all changed
+UI files pass targeted lint. These baseline issues are not silently fixed,
+suppressed, or represented as a green full-suite result by this prerequisite.

--- a/spec/features/job-progress-observability/user-stories.md
+++ b/spec/features/job-progress-observability/user-stories.md
@@ -1,0 +1,33 @@
+# User stories: shared job progress
+
+## US-001: observe a running job
+
+As an analyst, I want status and available progress while work runs so I can
+distinguish active computation from waiting or failure.
+
+Acceptance: empty/partial telemetry does not crash polling; recorded epoch
+and elapsed information becomes visible without inventing an ETA.
+
+## US-002: observe completion without optional telemetry
+
+As an analyst, I want successful completion to be visible even if the event
+file is unavailable.
+
+Acceptance: successful business completion reports complete progress;
+failure/cancellation remain distinct; missing messages do not hide status.
+
+## US-003: inspect live workflow output
+
+As a developer, I want child stdout/stderr while a workflow step is still
+running so I can diagnose slow work without restarting it.
+
+Acceptance: both streams are visible before child exit; nonzero exits stay
+explicit in workflow status and backend logs.
+
+## Agent Assignment Map
+
+| Story | Implementing agent | Validating agent |
+|---|---|---|
+| US-001 | backend-dev; ui | backend-validation; ui-validation |
+| US-002 | backend-dev; ui | backend-validation; ui-validation |
+| US-003 | backend-dev | backend-validation |

--- a/spec/features/stacked-pr-validation/design.md
+++ b/spec/features/stacked-pr-validation/design.md
@@ -6,6 +6,12 @@ Remove only the default-branch filter on existing `pull_request` triggers.
 Keep path filters, push/schedule behavior, permissions, action pins, and
 build/publish conditions unchanged.
 
+Secret-scan failures must include actionable file/line diagnostics while
+fully redacting matched values. Verbose output stays paired with
+`--redact=100` and a nonzero findings exit code in every scan mode. Historical
+false positives are handled by exact fingerprints, never by excluding
+whole test directories or weakening detection rules.
+
 ## Trust boundary
 
 The wheel build remains credential-free. The trusted publisher continues

--- a/ui/package.json
+++ b/ui/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "test:interactive-labeler": "node --test src/Components/InteractiveLabeler/interactiveLabelerLoading.test.js src/Components/guidedTourLayout.test.js",
     "test:ongoing-jobs": "node --test src/Components/Home/ongoingJobs.test.js",
+    "test:job-progress": "node --test src/Components/OtherComponents/StatusIndicatorHelper.test.js",
     "test:label-store": "node --test src/Components/InteractiveLabeler/labelStore.test.js",
     "test:validation-config": "node --test src/Components/BuildingValidation/validationConfig.test.js",
     "preview": "vite preview"

--- a/ui/src/Components/OtherComponents/MessageProgressBar.jsx
+++ b/ui/src/Components/OtherComponents/MessageProgressBar.jsx
@@ -6,33 +6,45 @@ import React from "react";
 import PropTypes from "prop-types";
 import "../../assets/css/progress-bar.css";
 
-const MessageProgressBar = ({ progress, message, stepText }) => {
-    MessageProgressBar.propTypes = {
-    progress: PropTypes.string.isRequired,
-    message: PropTypes.string,
-    stepText: PropTypes.string,
-  };
-  
+const MessageProgressBar = ({ progress, message = "", stepText = "", indeterminate = false }) => {
+  const numeric = typeof progress === "string" && progress.trim() !== "" && Number.isFinite(Number(progress));
+  const value = numeric ? Math.min(100, Math.max(0, Number(progress))) : undefined;
+  const label = !indeterminate && !numeric && progress
+    ? progress
+    : [message, stepText].filter(Boolean).join(" : ");
 
   return (
     <React.Fragment>
       <div className="message-progress">
-        <div className="meter p-0 message-progress-meter">
+        <div
+          className={`meter p-0 message-progress-meter${indeterminate ? " message-progress-indeterminate" : ""}`}
+          role="progressbar"
+          aria-label={message || "Job progress"}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={indeterminate ? undefined : value}
+          aria-valuetext={label}
+        >
           <span
-            style={{ width: isNaN(progress) ? "0%" : progress + "%" }}
+            style={indeterminate ? undefined : { width: `${value ?? 0}%` }}
           ></span>
         </div>
 
         <span className="message-progress-text">
-          <Text className="text-light progress-text">
-            {isNaN(progress) ? progress : `${message} : ${stepText}`.length > 31 
-              ? `${message} : ${stepText}`.substring(0, 31) + '...' 
-              : `${message} : ${stepText}`}
+          <Text className="text-light progress-text" title={label}>
+            {label}
           </Text>
         </span>
       </div>
     </React.Fragment>
   );
+};
+
+MessageProgressBar.propTypes = {
+  progress: PropTypes.string,
+  message: PropTypes.string,
+  stepText: PropTypes.string,
+  indeterminate: PropTypes.bool,
 };
 
 export default MessageProgressBar;

--- a/ui/src/Components/OtherComponents/StatusIndicator.jsx
+++ b/ui/src/Components/OtherComponents/StatusIndicator.jsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 // Components
-import React, { useEffect, useState } from "react";
+import React, { useMemo, useState } from "react";
 import MessageProgressBar from "../OtherComponents/MessageProgressBar";
 import StatusIndicatorModal from "./StatusIndicatorModal";
 import { validateTimestamp } from "../../util/validation";
@@ -9,78 +9,31 @@ import { validateTimestamp } from "../../util/validation";
 import PropTypes from "prop-types";
 import { Button } from "@fluentui/react-components";
 import { FluentIcon } from "../../util/icons";
+import { statusPresentation } from "./StatusIndicatorHelper";
 
-const StatusIndicator = ({ currentStep, totalSteps, progressPct, status, statusMessage, id, prefix = "Status", infoMetadata, contextLabel }) => {
-  StatusIndicator.propTypes = {
-    currentStep: PropTypes.number.isRequired,
-    totalSteps: PropTypes.number.isRequired,
-    progressPct: PropTypes.number.isRequired,
-    status: PropTypes.string.isRequired,
-    statusMessage: PropTypes.string.isRequired,
-    id: PropTypes.string,
-    // Optional list of {label, value} run parameters surfaced above the
-    // status-message table in the info modal (e.g. embedding-model row
-    // run params). When omitted the modal only shows the message log.
-    infoMetadata: PropTypes.arrayOf(
-      PropTypes.shape({
-        label: PropTypes.string.isRequired,
-        value: PropTypes.node.isRequired,
-      })
-    ),
-    // Optional label identifying the element these messages belong to
-    // (e.g. "Image Layer: Pre-event"). Passed through to the info panel.
-    contextLabel: PropTypes.string,
-  };
-  
-
-  const [statusMessageList, setStatusMessageList] = React.useState([]);
-
-  const labelsToReplace = [
+const labelsToReplace = [
     { original: "trainStartTime:", replacement: "Training start time:" },
     { original: "epoch:", replacement: "Epoch: " },
     { original: "elapsedDurationInMinutes:", replacement: "Minutes Elapsed:" },
     { original: "approxMinutesToComplete:", replacement: "Aprox. minutes to complete: " },
     { original: "completedDate:", replacement: "Completed date:" }
-  ];
+];
 
+const StatusIndicator = ({ currentStep, totalSteps, progressPct, status, statusMessage, id, prefix = "Status", infoMetadata, contextLabel }) => {
   const [isModalVisible, setIsModalVisible] = useState(false);
-
-  useEffect(() => {
-    if (statusMessage) {
-
-      var tempStatusMessages = statusMessage;
-
-      labelsToReplace.forEach(label => {
-        tempStatusMessages = tempStatusMessages.replace(new RegExp(label.original, 'g'), label.replacement);
-      });
-      
-      tempStatusMessages = tempStatusMessages.split("\n");
-      var newStatusMessages = [];
-      if (tempStatusMessages.length > 0) {
-        for (let i = 0; i < tempStatusMessages.length; i++) {
-          if (validateTimestamp(tempStatusMessages[i])) {
-            newStatusMessages.push({
-              message: tempStatusMessages[i].substring(33),
-              timestamp:
-                tempStatusMessages[i].substring(0, 10) +
-                ", " +
-                tempStatusMessages[i].substring(11, 19) +
-                " UTC",
-            });
-          } else {
-            newStatusMessages.push({
-              message: tempStatusMessages[i],
-              timestamp: "",
-            });
-          }
+  const statusMessageList = useMemo(() => {
+    if (!statusMessage) return [];
+    let formatted = statusMessage;
+    labelsToReplace.forEach(label => {
+      formatted = formatted.replace(new RegExp(label.original, "g"), label.replacement);
+    });
+    return formatted.split("\n").map(line => validateTimestamp(line)
+      ? {
+          message: line.substring(33),
+          timestamp: `${line.substring(0, 10)}, ${line.substring(11, 19)} UTC`,
         }
-        setStatusMessageList(newStatusMessages);
-      } else {
-        setStatusMessageList([]);
-      }
-    }
-
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+      : { message: line, timestamp: "" }
+    );
   }, [statusMessage]);
 
 
@@ -94,35 +47,28 @@ const StatusIndicator = ({ currentStep, totalSteps, progressPct, status, statusM
   }
 
 
-  // If is an old project, will only show the status message
-  if(currentStep===undefined || totalSteps===undefined || progressPct===undefined) {
-    return (
-      <div className={`modelStatus modelStatus-${status}`}>
-      <span className="fw-semibold"></span>
-      {prefix}: {status}
-    </div>
-    );
-  }
+  const presentation = statusPresentation({ status, currentStep, totalSteps, progressPct });
+  const hasDetails = statusMessageList.length > 0 || Boolean(infoMetadata?.length);
   
 
   return (
     <React.Fragment>
-      {statusMessageList.length > 0 && (
         <div className="d-flex flex-row align-items-center">
-          {status === "Processed" || status === "Failed"  || status === "Cancelled" ? (
-            <div className={`modelStatus modelStatus-${status}`}>
+          {!presentation.active ? (
+            <div className={`modelStatus modelStatus-${presentation.label}`}>
               <span className="fw-semibold"></span>
-              {status === "Cancelled" ? getLastMessageWithTimestamp(statusMessageList[0]) : `${prefix}: ${status}`}
+              {`${prefix}: ${presentation.label}`}
             </div>
           ) : (
             <MessageProgressBar
-              progress={progressPct.toString()}
-              message={getLastMessageWithTimestamp(statusMessageList[0])}
-              stepText={currentStep + "/" + totalSteps}
+              progress={presentation.progress?.toString()}
+              indeterminate={presentation.indeterminate}
+              message={getLastMessageWithTimestamp() || presentation.label}
+              stepText={presentation.stepText}
             />
           )}
 
-          <Button
+          {hasDetails && <Button
             id={id}
             appearance="subtle"
             icon={<FluentIcon name="Info" />}
@@ -132,9 +78,8 @@ const StatusIndicator = ({ currentStep, totalSteps, progressPct, status, statusM
             onClick={() => {
               setIsModalVisible(true);
             }}
-          />
+          />}
         </div>
-      )}
 
 
       {isModalVisible && (
@@ -150,6 +95,23 @@ const StatusIndicator = ({ currentStep, totalSteps, progressPct, status, statusM
 
     </React.Fragment>
   );
+};
+
+StatusIndicator.propTypes = {
+  currentStep: PropTypes.number,
+  totalSteps: PropTypes.number,
+  progressPct: PropTypes.number,
+  status: PropTypes.string,
+  statusMessage: PropTypes.string,
+  id: PropTypes.string,
+  prefix: PropTypes.string,
+  infoMetadata: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      value: PropTypes.node.isRequired,
+    })
+  ),
+  contextLabel: PropTypes.string,
 };
 
 export default StatusIndicator;

--- a/ui/src/Components/OtherComponents/StatusIndicatorHelper.js
+++ b/ui/src/Components/OtherComponents/StatusIndicatorHelper.js
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const activeStates = new Set(["Queued", "InProgress"]);
+
+export function statusPresentation({ status, currentStep, totalSteps, progressPct }) {
+  const label = typeof status === "string" && status ? status : "Unknown";
+  const active = activeStates.has(label);
+  const hasCounters =
+    Number.isFinite(currentStep) && currentStep >= 0 &&
+    Number.isFinite(totalSteps) && totalSteps > 0;
+  const hasProgress =
+    label !== "Queued" && Number.isFinite(progressPct) &&
+    (progressPct > 0 || (hasCounters && currentStep > 0));
+
+  return {
+    label,
+    active,
+    indeterminate: active && !hasProgress,
+    progress: hasProgress ? Math.min(100, Math.max(0, progressPct)) : null,
+    stepText: hasProgress && hasCounters ? `${currentStep}/${totalSteps}` : "",
+  };
+}

--- a/ui/src/Components/OtherComponents/StatusIndicatorHelper.test.js
+++ b/ui/src/Components/OtherComponents/StatusIndicatorHelper.test.js
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { statusPresentation } from "./StatusIndicatorHelper.js";
+
+test("queued jobs remain visible without messages or counters", () => {
+  assert.deepEqual(statusPresentation({ status: "Queued" }), {
+    label: "Queued", active: true, indeterminate: true, progress: null, stepText: "",
+  });
+});
+
+test("missing initial telemetry is indeterminate, not invented zero progress", () => {
+  assert.equal(statusPresentation({
+    status: "InProgress", currentStep: 0, totalSteps: 2, progressPct: 0,
+  }).indeterminate, true);
+});
+
+test("valid shared backend counters are rendered", () => {
+  assert.deepEqual(statusPresentation({
+    status: "InProgress", currentStep: 1, totalSteps: 4, progressPct: 25,
+  }), {
+    label: "InProgress", active: true, indeterminate: false, progress: 25, stepText: "1/4",
+  });
+});
+
+test("terminal states do not depend on metrics or log messages", () => {
+  for (const status of ["Processed", "Failed", "Cancelled"]) {
+    const view = statusPresentation({ status, progressPct: 0 });
+    assert.equal(view.label, status);
+    assert.equal(view.active, false);
+    assert.equal(view.indeterminate, false);
+  }
+});
+
+test("unknown and malformed progress stays unavailable", () => {
+  for (const progressPct of [undefined, null, Number.NaN, Infinity, "50"]) {
+    const view = statusPresentation({
+      status: "InProgress", currentStep: 1, totalSteps: 2, progressPct,
+    });
+    assert.equal(view.indeterminate, true);
+    assert.equal(view.progress, null);
+  }
+  assert.equal(statusPresentation({}).label, "Unknown");
+});
+
+test("progress is bounded without changing the underlying state", () => {
+  assert.equal(statusPresentation({
+    status: "InProgress", currentStep: 5, totalSteps: 4, progressPct: 125,
+  }).progress, 100);
+});
+
+test("recorded percentage is not hidden when legacy step counters are missing", () => {
+  const view = statusPresentation({ status: "InProgress", progressPct: 25 });
+  assert.equal(view.progress, 25);
+  assert.equal(view.indeterminate, false);
+  assert.equal(view.stepText, "");
+});

--- a/ui/src/assets/css/progress-bar.css
+++ b/ui/src/assets/css/progress-bar.css
@@ -90,6 +90,24 @@
 
   .message-progress-meter {
     border-radius: 5px;
+    overflow: hidden;
+  }
+
+  .message-progress-indeterminate > span {
+    width: 35%;
+    animation: indeterminate-job-progress 1.8s linear infinite;
+  }
+
+  @keyframes indeterminate-job-progress {
+    from { transform: translateX(-100%); }
+    to { transform: translateX(300%); }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .message-progress-indeterminate > span,
+    .meter > span:after {
+      animation: none;
+    }
   }
 
   .message-progress-text {

--- a/ui/tests/fixtures/job-progress.html
+++ b/ui/tests/fixtures/job-progress.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Job progress component fixture</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./job-progress.jsx"></script>
+  </body>
+</html>

--- a/ui/tests/fixtures/job-progress.jsx
+++ b/ui/tests/fixtures/job-progress.jsx
@@ -1,0 +1,40 @@
+import { useState } from "react";
+import { createRoot } from "react-dom/client";
+import { Button, FluentProvider, webLightTheme } from "@fluentui/react-components";
+import StatusIndicator from "../../src/Components/OtherComponents/StatusIndicator";
+
+const cases = {
+  Queued: { status: "Queued", currentStep: 0, totalSteps: 2, progressPct: 0, statusMessage: "" },
+  "Running without metrics": { status: "InProgress", currentStep: 0, totalSteps: 2, progressPct: null, statusMessage: "" },
+  "Running with metrics": {
+    status: "InProgress", currentStep: 1, totalSteps: 4, progressPct: 25,
+    statusMessage: "2026-01-01T00:00:00.000000+00:00: Training in progress",
+  },
+  "Percentage without counters": { status: "InProgress", progressPct: 25, statusMessage: "" },
+  Processed: { status: "Processed", currentStep: 0, totalSteps: 2, progressPct: 0, statusMessage: "" },
+  Failed: { status: "Failed", statusMessage: "" },
+  Cancelled: { status: "Cancelled", statusMessage: "" },
+  Legacy: { status: "InProgress" },
+};
+
+export function Fixture() {
+  const [value, setValue] = useState(cases.Queued);
+  return (
+    <FluentProvider theme={webLightTheme}>
+      <h1>Job progress fixture</h1>
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+        {Object.entries(cases).map(([name, props]) => (
+          <Button key={name} onClick={() => setValue(props)}>{name}</Button>
+        ))}
+        <Button onClick={() => setValue(previous => ({ ...previous, statusMessage: "" }))}>
+          Clear messages
+        </Button>
+      </div>
+      <div data-testid="status" style={{ padding: 24 }}>
+        <StatusIndicator {...value} />
+      </div>
+    </FluentProvider>
+  );
+}
+
+createRoot(document.getElementById("root")).render(<Fixture />);


### PR DESCRIPTION
## Purpose

Make job progress and logs visible and truthful: stream workflow output,
read live TensorBoard files, show terminal states without requiring logs,
and display unknown progress rather than inventing zero percent.

## Changes

- Resolve exact, nested, and generated files within the correct task.
- Handle partial, missing, ambiguous, and non-finite telemetry explicitly.
- Stream child stdout/stderr and preserve workflow stage messages.
- Keep status visible with empty messages and indeterminate counters.
- Preserve the lifecycle prerequisite's state and output-persistence rules.

The refresh preserved the previous runtime/UI contents. Balanced review
follow-ups now anchor local output reads to trusted descriptors through
the final open, force unbuffered child output, and retain complete workflow
history before failed/cancelled summaries and cleanup. Native Windows
descriptor limitations fail explicitly instead of using an unsafe fallback.
The branch does not contain #216's publishing implementation or AML changes.

## Validation and dependencies

The refreshed branch passes 33 targeted backend/workflow regressions
(one platform skip), seven UI helper cases, and the repository hooks.
The test invocation uses importlib mode to avoid collisions between the
library and container test-package names.

Review follow-ups and the updated lifecycle prerequisite passed 224
combined host cases with 31 platform skips. The real non-root Linux
descriptor/path suites passed 27 cases with one Windows-only skip, with
networking disabled and source mounted read-only. All three review threads
have fix/evidence replies and are resolved.

Base: #217. This dependency is intentional: the local output reader uses
the lifecycle's execution-identity validation. Review can proceed in
parallel, but merge only after #217 lands and this PR is retargeted to main.

Current main-only workflow filters can skip checks against this stacked
base. #216's small coverage change, or retargeting to main after #217 lands,
resolves that limitation; missing checks are not represented as passed.
#193 remains the complete integration draft. No deployment is authorized.
